### PR TITLE
Add rows to fix getting started section on homepage

### DIFF
--- a/templates/index.dtl
+++ b/templates/index.dtl
@@ -64,11 +64,15 @@
       </div>
       {% endif %}
     </div>
+  </div>
 
+  <div class="row">
     <div class="col-lg-12">
       <div class="divider"><p/></div>
     </div>
+  </div>
 
+  <div class="row">
     <div class="col-lg-6">
       <h3 class="sub-headlines">MAILINGLIST HEADLINES</h3>
       <div class="inside-cols">


### PR DESCRIPTION
Adds additional divs to create what should be three rows for News/Getting Started, and Mailing List sections. Without this fix:

* the page is too wide, since the columns overrun
* in single column view the Getting Started buttons cannot be clicked