### PR TITLE
Sort using version numbers instead of release string

### DIFF
--- a/src/handlers/erlorg_versions_handler.erl
+++ b/src/handlers/erlorg_versions_handler.erl
@@ -36,7 +36,10 @@ versions() ->
   {ok, Regex} = re:compile(DocBase ++ "(?<VER>.*)"),
 
   Versions = [version(DocBase, Regex, FilePath) || FilePath <- Paths],
-  lists:reverse(Versions).
+  lists:reverse(Versions),
+  lists:sort(
+    fun(X, Y) -> maps:get(version, X) > maps:get(version, Y) end,
+    Versions).
 
 version(DocBase, Regex, Path) ->
   {match, [{A, B}]} = re:run(Path, Regex, [{capture, ['VER']}]),


### PR DESCRIPTION
http://www.erlang.org/docs/versions