### PR TITLE
Update example-even-nums-parallel.erl

### DIFF
--- a/_includes/example-even-nums-parallel.erl
+++ b/_includes/example-even-nums-parallel.erl
@@ -5,4 +5,4 @@ even(Numbers) ->
 mapreduce(Numbers, Function) ->
   Parent = self(),
   [spawn(fun() -> Parent ! {Number, Function(Number)} end) || Number <- Numbers],
-  [receive {Number, Even} -> Even || Number <- Numbers].
+  [receive {Number, Even} -> {Number, Even} end || Number <- Numbers].


### PR DESCRIPTION
There was a missing `end` on the receive, and the function was only returning `Even`,
when the spec says it would return a tuple.