### PR TITLE
Add webrick to bundle

### DIFF
--- a/.devcontainer/Gemfile
+++ b/.devcontainer/Gemfile
@@ -6,3 +6,5 @@ group :jekyll_plugins do
   gem 'jekyll-feed'
   gem 'jekyll-liquify'
 end
+
+gem "webrick", "~> 1.7"

--- a/.devcontainer/Gemfile.lock
+++ b/.devcontainer/Gemfile.lock
@@ -63,8 +63,10 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -72,6 +74,7 @@ DEPENDENCIES
   jekyll-feed
   jekyll-liquify
   json (>= 2.0.0)
+  webrick (~> 1.7)
 
 BUNDLED WITH
    2.2.27


### PR DESCRIPTION
This commit merely adds webrick (http server) to the bundle as a work-around in lieu of updating jekyll in case
someone is using ruby 3.x

Reference: https://github.com/jekyll/jekyll/issues/8523

Note that alternatively, we could simply update jekyll since it now explicitly has webrick in it's gem spec. 