### PR TITLE
Fix typo in title of small process example

### DIFF
--- a/_examples/5-processes-small.md
+++ b/_examples/5-processes-small.md
@@ -1,5 +1,5 @@
 ---
-description: Light-weigth processes
+description: Light-weight processes
 display: small
 ---
 <!-- This file has to be 13 lines long -->


### PR DESCRIPTION
Noticed this on the home-page carousel then checking out the new site.