### PR TITLE
Correct case of project names in the About page

### DIFF
--- a/about.md
+++ b/about.md
@@ -5,11 +5,11 @@ layout: markdown
 
 ### Core Development
 
-Erlang is a programming language originally developed at the Ericsson Computer Science Laboratory. OTP (Open Telecom Platform) is a collection of middleware and libraries in Erlang. Erlang/OTP has been battle tested in a number of Ericsson products for building robust fault-tolerant distributed applications, for example AXD301 (ATM switch). Main developer and maintainer is the Erlang/OTP unit at Ericsson. 
+Erlang is a programming language originally developed at the Ericsson Computer Science Laboratory. OTP (Open Telecom Platform) is a collection of middleware and libraries in Erlang. Erlang/OTP has been battle tested in a number of Ericsson products for building robust fault-tolerant distributed applications, for example AXD301 (ATM switch). Main developer and maintainer is the Erlang/OTP unit at Ericsson.
 
 ### erlang.org
 
-The source code for this webpage is available on [github](https://github.com/erlang/erlang-org). It is built using [Erlang](https://erlang.org), [jekyll](https://jekyllrb.com/), [bootstrap 5](https://getbootstrap.com/docs/5.0/) and [Node JS](https://nodejs.org/).
+The source code for this webpage is available on [GitHub](https://github.com/erlang/erlang-org). It is built using [Erlang](https://erlang.org), [Jekyll](https://jekyllrb.com/), [Bootstrap 5](https://getbootstrap.com/docs/5.0/) and [Node.js](https://nodejs.org/).
  
 ### License
 Since OTP 18.0, Erlang/OTP is released under Apache License 2.0. The older releases were released under Erlang Public License (EPL), a derivative work of the Mozilla Public License (MPL).


### PR DESCRIPTION
Minor change - but it feels more respectful when using third-party projects' names correctly.