### PR TITLE
maps module doc has broken link fix OTP GH-6155

### DIFF
--- a/_scripts/otp_flatten_docs
+++ b/_scripts/otp_flatten_docs
@@ -278,10 +278,10 @@ sub copy_html {
 		    $part =~ tr/\'//d;
 		    my $mod_name = $mod;
 		    $mod_name =~ s/#.*$//;
-		    if ($module{$mod_name}) {
-			$href = path_to("man/$mod", $rel);
-		    } elsif ($part =~ m@doc/(.*)@) {
+		    if ($part =~ m@doc/(.*)@) {
 			$href = path_to($1, $rel) . "/$mod";
+		    } elsif ($module{$mod_name}) {
+			$href = path_to("man/$mod", $rel);
 		    } else {
 			$href = path_to("apps/$part/$mod", $rel);
 		    }


### PR DESCRIPTION
The documentation for the module stdlib/maps.html had a problem
when rewriting a Erlhref link pointing to the efficiency_guide/maps.html
page. Since maps.html is name of the page that documents the module maps,
otp_flatten_docs script got confused.