### PR TITLE
gh: use ubuntu-20.04 instead of latest

### DIFF
--- a/.github/workflows/update-gh-cache.yaml
+++ b/.github/workflows/update-gh-cache.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-deploy:
     if: github.repository == 'erlang/erlang-org'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1


### PR DESCRIPTION
- currently rebar3 is missing in ubuntu-22.04