### PR TITLE
Make footer sticky

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 ---
 ---
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: "en" }}">
+<html lang="{{ site.lang | default: "en" }}" class="h-100">
 
 {% assign default_title=page.name| split: "." | first | capitalize %}
 {% assign title=page.title | default: default_title | append: " - " | append: site.title %}
@@ -49,7 +49,7 @@
     <link rel="stylesheet" href="{{ '/assets/css/' | append: css | append: '.css' | relative_url }}">
 </head>
 
-<body>
+<body class="d-flex flex-column h-100">
     <header class="navbar navbar-expand-lg navbar-light bg-body">
         <nav class="container">
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-bs-toggle="collapse"
@@ -78,8 +78,10 @@
             </div>
         </nav>
     </header>
-    {{ content }}
-    <footer class="container-fluid footer text-center border-top border-bottom">
+    <div class="flex-shrink-0">
+        {{ content }}
+    </div>
+    <footer class="container-fluid footer mt-auto text-center border-top border-bottom">
         <div>
             <a href="{{ '/downloads.html' | relative_url }}" title="DOWNLOAD"><img src="{{ '/assets/img/download.png' | relative_url }}" alt="Download Erlang/OTP"></a>
         </div>

--- a/_sass/_default.scss
+++ b/_sass/_default.scss
@@ -73,7 +73,6 @@ blockquote.blockquote {
 }
 
 .footer {
-  @include my(3);
   @include py(3);
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(50px, 1fr));


### PR DESCRIPTION
This is mostly noticeable on pages like ["About"](https://www.erlang.org/about), where there isn't enough content per screen space to make the footer go down. Now it will always be fixed to the bottom.

<img width="1728" alt="image" src="https://github.com/erlang/erlang-org/assets/23292709/ff4bf943-5b4b-4453-aab4-18e1c09c2562">
