### PR TITLE
Add search across versions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,7 +65,6 @@ exclude:
   - assets/doc-search*
   - docs/doc
   - _patches/releases.json
-  - search.html
 
 ## We use the kramdown renderer as it gives us better possibilities
 ## to configure how it should work and is used by many more project.

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -1,4 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+---
+---
+{% raw %}
+<!DOCTYPE>
 <html>
 
 <head>
@@ -250,10 +253,13 @@
 						</a>
 					</div>
 					<div class="search-refinements">
+                                                 <h4>Versions</h4>
+                                                 <div class="search-refinements-version" id="version-list"></div>
 						<h4>Documentation Type</h4>
 						<div class="search-refinements-type" id="type-list"></div>
 						<h4>Applications</h4>
 						<div class="search-refinements-app" id="app-list"></div>
+
 						<div class="search-clear-refinements" id="clear-refinements"></div>
 					</div>
 				</div>
@@ -269,21 +275,19 @@
 		</div>
 	</div>
 
-	<script src="/assets/js/doc-search.bundle.js"></script>
-
 	<script type=text/html id=hit-template>
 		<a href="{{ url }}" class=hit>
 			<div class=hit-content>
 				<h3 class="hit-name lvl0">
 				{{#isModule}}
-				{{{_highlightResult.hierarchy.lvl1.value}}}{{#_highlightResult.hierarchy.lvl2.value}}:{{{_highlightResult.hierarchy.lvl2.value}}}{{/_highlightResult.hierarchy.lvl2.value}}
-				{{/isModule}}
-				{{^isModule}}
-				{{{_highlightResult.hierarchy.lvl1.value}}} {{#_highlightResult.hierarchy.lvl2.value}} → {{{_highlightResult.hierarchy.lvl2.value}}}{{/_highlightResult.hierarchy.lvl2.value}} {{#_highlightResult.hierarchy.lvl3.value}} → {{{_highlightResult.hierarchy.lvl3.value}}}{{/_highlightResult.hierarchy.lvl3.value}}
-				{{/isModule}}
+                               {{{_highlightResult.hierarchy.lvl1.value}}}{{#_highlightResult.hierarchy.lvl2.value}}:{{{_highlightResult.hierarchy.lvl2.value}}}{{/_highlightResult.hierarchy.lvl2.value}}
+                               {{/isModule}}
+                               {{^isModule}}
+                               {{{_highlightResult.hierarchy.lvl1.value}}} {{#_highlightResult.hierarchy.lvl2.value}} → {{{_highlightResult.hierarchy.lvl2.value}}}{{/_highlightResult.hierarchy.lvl2.value}} {{#_highlightResult.hierarchy.lvl3.value}} → {{{_highlightResult.hierarchy.lvl3.value}}}{{/_highlightResult.hierarchy.lvl3.value}}
+                               {{/isModule}}
 				</h3>
 				<div class="hit-tag">{{#tags}}<code><small>{{.}}</small></code>&nbsp;{{/tags}}</div>
-				<div class="hit-text">{{{_snippetResult.content.value}}}</div>
+                               <div class="hit-text">{{{_snippetResult.content.value}}}</div>
 			</div>
 		</a>
 	</script>
@@ -291,29 +295,11 @@
 	<script>
 		const searchClient = algoliasearch('LUYTU1J2MB', '86152ba1d4a9d7e179d537b8060a4c31');
 		const search = instantsearch({
-			indexName: 'erlang',
-			searchClient,
-			routing: {
-				stateMapping: {
-					stateToRoute: function (uiState) {
-						return {
-							q: uiState['erlang'].query,
-						};
-					},
-					routeToState: function (routeState) {
-						return {
-							erlang: {
-								query: routeState.q,
-							},
-						};
-					},
-				}
-			}
+		    indexName: 'erlang',
+		    searchClient,
 		});
+                const urlParams = new URLSearchParams(window.location.search);
 	        search.addWidgets([
-                        instantsearch.widgets.configure({
-                            filters: 'docEngine:erl_docgen'
-                        }),
 			instantsearch.widgets.searchBox({
 				container: '#searchbox',
 				placeholder: 'Search erlang documentation',
@@ -343,9 +329,25 @@
 				showMoreLimit: 100,
 				limit: 10,
 			}),
+                    	instantsearch.widgets.refinementList({
+				container: '#version-list',
+				attribute: 'version',
+				limit: 10,
+			}),
+                    instantsearch.widgets.configure({
+                        query: urlParams.get('q'),
+                        disjunctiveFacetsRefinements: {
+                            {% endraw %}
+                            version:[urlParams.get('v') ? urlParams.get('v') : '{{ page.version }}']
+                            {% raw %}
+                        }
+                    }),
 		]);
-		search.start();
+	  search.start();
+{% endraw %}
+          _docsearch_version = "{{ page.version }}";
 	</script>
+        <script src="/assets/js/doc-search.bundle.js"></script>        
 </body>
 
 </html>

--- a/_scripts/download-docs.sh
+++ b/_scripts/download-docs.sh
@@ -93,8 +93,6 @@ for ARCHIVE in docs/*.tar.gz; do
         _flatten_docs "${ERTS_VSN}" "${MAJOR_VSN}"
         rm -rf "docs/doc" || true
         mv docs/doc-1 docs/doc
-        URL=$(grep "^url: " _config.yml | sed 's@url: "\([^"]*\)".*@\1@')
-        BASEURL=$(grep "^baseurl: " _config.yml | sed 's@baseurl: "\([^"]*\)".*@\1@')
         printf -- '---\nlayout: search\nversion: %s\n---\n' "${MAJOR_VSN}" > "docs/doc/search.html"
     fi
     _flatten_docs "${ERTS_VSN}" "${MAJOR_VSN}"
@@ -105,5 +103,7 @@ for ARCHIVE in docs/*.tar.gz; do
     rm -f "${ARCHIVE}"
 done
 
+URL=$(grep "^url: " _config.yml | sed 's@url: "\([^"]*\)".*@\1@')
+BASEURL=$(grep "^baseurl: " _config.yml | sed 's@baseurl: "\([^"]*\)".*@\1@')
 MAJOR_VSNs=$(echo "${MAJOR_VSNs}" | tr '\n' ' ')
-_scripts/otp_doc_sitemap.sh "docs" "${MAJOR_VSNs}" "${LATEST_MAJOR_VSN}" "${URL}${BASEURL}/" > docs/sitemap_algolia.xml
+_scripts/otp_doc_sitemap.sh "${MAJOR_VSNs}" "${LATEST_MAJOR_VSN}" "${URL}${BASEURL}" > docs/sitemap_algolia.xml

--- a/_scripts/download-docs.sh
+++ b/_scripts/download-docs.sh
@@ -95,7 +95,6 @@ for ARCHIVE in docs/*.tar.gz; do
         mv docs/doc-1 docs/doc
         URL=$(grep "^url: " _config.yml | sed 's@url: "\([^"]*\)".*@\1@')
         BASEURL=$(grep "^baseurl: " _config.yml | sed 's@baseurl: "\([^"]*\)".*@\1@')
-        _scripts/otp_doc_sitemap.sh doc/ "${URL}${BASEURL}/" > doc/sitemap_algolia.xml
         printf -- '---\nlayout: search\nversion: %s\n---\n' "${MAJOR_VSN}" > "docs/doc/search.html"
     fi
     _flatten_docs "${ERTS_VSN}" "${MAJOR_VSN}"
@@ -107,10 +106,4 @@ for ARCHIVE in docs/*.tar.gz; do
 done
 
 MAJOR_VSNs=$(echo "${MAJOR_VSNs}" | tr '\n' ' ')
-printf -- '---\nlayout: docs_list\nreleases:\n' > docs/list.html
-for v in ${MAJOR_VSNs}; do
-    if [ "$v" -gt 23 ]; then
-        printf -- '  - %s\n' "$v" >> docs/list.html
-    fi
-done
-printf -- '---\n' >> docs/list.html
+_scripts/otp_doc_sitemap.sh "docs" "${MAJOR_VSNs}" "${LATEST_MAJOR_VSN}" "${URL}${BASEURL}/" > docs/sitemap_algolia.xml

--- a/_scripts/download-docs.sh
+++ b/_scripts/download-docs.sh
@@ -29,7 +29,7 @@ _get_doc_hash() {
 }
 
 _flatten_docs() {
-    if [ "$3" -ge "27" ]; then
+    if [ -f "docs/doc-$1/doc/readme.html" ]; then
         (cd docs && ../_scripts/otp_flatten_ex_docs "doc-$1" "$2")
     else
         (cd docs && ../_scripts/otp_flatten_docs "doc-$1" "$2")
@@ -67,6 +67,7 @@ for rc_ver in 5 4 3 2 1; do
     ARCHIVE="docs/otp_doc_html_${LATEST_VSN}.tar.gz"
     echo "Checking for ${LATEST_VSN} on github"
     if curl --silent --location --fail --show-error "${HDR[@]}" "https://github.com/erlang/otp/releases/download/OTP-${LATEST_VSN}/otp_doc_html_${LATEST_VSN}.tar.gz" > "${ARCHIVE}"; then
+        MAJOR_VSNs="${POSSIBLE_RC_VER} ${MAJOR_VSNs}"
         break;
     fi
     rm "${ARCHIVE}"
@@ -89,18 +90,27 @@ for ARCHIVE in docs/*.tar.gz; do
     MAJOR_VSN=$(echo "${VSN}" | awk -F. '{ print $1 }')
     mv "docs/tmp" "docs/doc-${ERTS_VSN}"
     if [ "${MAJOR_VSN}" = "${LATEST_MAJOR_VSN}" ]; then
-        _flatten_docs "${ERTS_VSN}" true "${MAJOR_VSN}"
+        _flatten_docs "${ERTS_VSN}" "${MAJOR_VSN}"
         rm -rf "docs/doc" || true
         mv docs/doc-1 docs/doc
         URL=$(grep "^url: " _config.yml | sed 's@url: "\([^"]*\)".*@\1@')
         BASEURL=$(grep "^baseurl: " _config.yml | sed 's@baseurl: "\([^"]*\)".*@\1@')
         _scripts/otp_doc_sitemap.sh doc/ "${URL}${BASEURL}/" > doc/sitemap_algolia.xml
-        ln -s ../../search.html docs/doc/search.html
+        printf -- '---\nlayout: search\nversion: %s\n---\n' "${MAJOR_VSN}" > "docs/doc/search.html"
     fi
-    _flatten_docs "${ERTS_VSN}" false "${MAJOR_VSN}"
+    _flatten_docs "${ERTS_VSN}" "${MAJOR_VSN}"
     touch "docs/doc-1/$(_get_doc_hash "${VSN}")"
     rm -rf "docs/${MAJOR_VSN}" || true
     mv docs/doc-1 "docs/${MAJOR_VSN}"
     rm -rf "docs/doc-${ERTS_VSN}"
     rm -f "${ARCHIVE}"
 done
+
+MAJOR_VSNs=$(echo "${MAJOR_VSNs}" | tr '\n' ' ')
+printf -- '---\nlayout: docs_list\nreleases:\n' > docs/list.html
+for v in ${MAJOR_VSNs}; do
+    if [ "$v" -gt 23 ]; then
+        printf -- '  - %s\n' "$v" >> docs/list.html
+    fi
+done
+printf -- '---\n' >> docs/list.html

--- a/_scripts/otp_doc_sitemap.sh
+++ b/_scripts/otp_doc_sitemap.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 VSNs="${1}"
-LATEST="${1}"
-BASEURL=${3}
+LATEST="${2}"
+BASEURL="${3}"
 DATE=$(date -Iseconds)
 
 cat <<EOF
@@ -14,7 +14,7 @@ EOF
 HTML_PAGES=$(find "doc/" -name "*.html")
 for page in ${HTML_PAGES}; do
             echo "   <url>
-      <loc>${BASEURL}${page}</loc>
+      <loc>${BASEURL}/${page}</loc>
       <lastmod>${DATE}</lastmod>
       <changefreq>weekly</changefreq>
    </url>"
@@ -25,7 +25,7 @@ for VSN in ${VSNs}; do
         HTML_PAGES=$(find "docs/${VSN}" -name "*.html")
         for page in ${HTML_PAGES}; do
             echo "   <url>
-      <loc>${BASEURL}${page}</loc>
+      <loc>${BASEURL}/${page}</loc>
       <lastmod>${DATE}</lastmod>
       <changefreq>weekly</changefreq>
    </url>"

--- a/_scripts/otp_doc_sitemap.sh
+++ b/_scripts/otp_doc_sitemap.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-ROOT=${1}
-BASEURL=${2}
-HTML_PAGES=$(find "${ROOT}" -name "*.html")
+VSNs="${1}"
+LATEST="${1}"
+BASEURL=${3}
 DATE=$(date -Iseconds)
 
 cat <<EOF
@@ -11,12 +11,26 @@ cat <<EOF
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 EOF
 
+HTML_PAGES=$(find "doc/" -name "*.html")
 for page in ${HTML_PAGES}; do
-    echo "   <url>
+            echo "   <url>
       <loc>${BASEURL}${page}</loc>
       <lastmod>${DATE}</lastmod>
       <changefreq>weekly</changefreq>
    </url>"
+done
+
+for VSN in ${VSNs}; do
+    if [ "${VSN}" -gt 23 ] && [ "${VSN}" != "${LATEST}" ]; then
+        HTML_PAGES=$(find "docs/${VSN}" -name "*.html")
+        for page in ${HTML_PAGES}; do
+            echo "   <url>
+      <loc>${BASEURL}${page}</loc>
+      <lastmod>${DATE}</lastmod>
+      <changefreq>weekly</changefreq>
+   </url>"
+        done
+    fi
 done
 
 cat <<EOF

--- a/_scripts/otp_flatten_docs
+++ b/_scripts/otp_flatten_docs
@@ -263,6 +263,9 @@ sub copy_html {
 		close DEST;
 		return copy_doc($src, $dest);
 	    }
+            if ($include_docsearch) {
+                s@(\s*)<title>@"$1<meta name=\"major-vsn\" content=\"" . $docsearch_version . "\">\n$&"@e;
+            }
 	    s@src="[^\"]*erlang-logo.svg"@"src=\"" . path_to("erlang-logo.svg", $rel) . '"' @e;
 	    s@src="[^\"]*flipmenu[.]js"@"src=\"" . path_to("js/flipmenu/flipmenu.js", $rel) . '"' @e;
 	    s@image[Pp]ath="[^\"]*flipmenu"@"imagePath=\"" . path_to("js/flipmenu", $rel) . '"' @e;

--- a/_scripts/otp_flatten_docs
+++ b/_scripts/otp_flatten_docs
@@ -21,11 +21,11 @@ if (@ARGV == 0) {
 
 my $src = shift;
 my $include_docsearch = 0;
-if (@ARGV == 1) {
-    if (shift eq "true") {
-        $include_docsearch = 1;
-    }
+my $docsearch_version = shift;
+if ($docsearch_version > 23) {
+    $include_docsearch = 1;
 }
+
 if (@ARGV != 0) {
     usage();
 }
@@ -421,15 +421,18 @@ sub get_analytics {
 }
 
 sub get_docsearch_js {
-    return <<'END'
+    return <<END
+<script type="text/javascript">
+_docsearch_version = "$docsearch_version";
+</script> 
 <script src="/assets/js/doc-search.bundle.js"></script>
 END
 }
 
 sub get_docsearch_html {
-    return <<'END'
+    return <<END
 <div id="docsearch"></div>
-<div style="padding-left: 1rem; padding-top: 0.1rem;"><a href="/doc/search">Paginated Search</a></div>
+<div style="padding-left: 1rem; padding-top: 0.1rem;"><a href="/doc/search?v=$docsearch_version">Paginated Search</a></div>
 END
 }
 

--- a/_scripts/otp_flatten_ex_docs
+++ b/_scripts/otp_flatten_ex_docs
@@ -56,11 +56,15 @@ _fixup_doc_links() {
 }
 
 _fixup_search_link() {
-    sed 's@<title>@<meta name="exdoc:full-text-search-url" content="/doc/search.html?v='"${MAJOR_VSN}"'\&q=">\n<title>@g' -i -- "$@"
+    sed 's@\s*<title>@<meta name="exdoc:full-text-search-url" content="/doc/search.html?v='"${MAJOR_VSN}"'\&q=">\n&@g' -i -- "$@"
+}
+
+_fixup_major_version() {
+    sed 's@\s*<title>@<meta name="major-vsn" content="'"${MAJOR_VSN}"'">\n&@g' -i -- "$@"
 }
 
 _disable_autocomplete() {
-    sed 's@<title>@<meta name="exdoc:autocomplete" content="off">\n<title>@g' -i -- "$@"
+    sed 's@\s*<title>@<meta name="exdoc:autocomplete" content="off">\n&@g' -i -- "$@"
 }
 
 mkdir "${TARGET_DIR}"
@@ -69,10 +73,12 @@ cp -r "${SOURCE_DIR}/doc/"* "${TARGET_DIR}/"
 _fixup_doc_links "${TARGET_DIR}/"*.html
 _fixup_search_link "${TARGET_DIR}/"*.html
 _disable_autocomplete "${TARGET_DIR}/"*.html
+_fixup_major_version "${TARGET_DIR}/"*.html
 cp -r "${SOURCE_DIR}/doc/system" "${TARGET_DIR}/system"
 _fixup_doc_links "${TARGET_DIR}/system/"*.html
 _fixup_search_link "${TARGET_DIR}/system/"*.html
 _disable_autocomplete "${TARGET_DIR}/system/"*.html
+_fixup_major_version "${TARGET_DIR}/system/"*.html
 
 mkdir "${TARGET_DIR}/apps"
 
@@ -85,6 +91,7 @@ for APP_VSN in ${APP_VSNS}; do
     fi
     _fixup_doc_links "${TARGET_DIR}/apps/${APP}/"*.html
     _fixup_search_link "${TARGET_DIR}/apps/${APP}/"*.html
+    _fixup_major_version "${TARGET_DIR}/apps/${APP}/"*.html
 done
 
 exit 0

--- a/_scripts/otp_flatten_ex_docs
+++ b/_scripts/otp_flatten_ex_docs
@@ -19,6 +19,7 @@ set -e
 set -o pipefail
 
 SOURCE_DIR="$1"
+MAJOR_VSN="$2"
 TARGET_DIR="$(dirname $1)/doc-1"
 INCLUDE_SEARCH="$1"
 
@@ -54,12 +55,24 @@ _fixup_doc_links() {
     sed $FIXUP -i -- "$@"
 }
 
+_fixup_search_link() {
+    sed 's@<title>@<meta name="exdoc:full-text-search-url" content="/doc/search.html?v='"${MAJOR_VSN}"'\&q=">\n<title>@g' -i -- "$@"
+}
+
+_disable_autocomplete() {
+    sed 's@<title>@<meta name="exdoc:autocomplete" content="off">\n<title>@g' -i -- "$@"
+}
+
 mkdir "${TARGET_DIR}"
 
 cp -r "${SOURCE_DIR}/doc/"* "${TARGET_DIR}/"
 _fixup_doc_links "${TARGET_DIR}/"*.html
+_fixup_search_link "${TARGET_DIR}/"*.html
+_disable_autocomplete "${TARGET_DIR}/"*.html
 cp -r "${SOURCE_DIR}/doc/system" "${TARGET_DIR}/system"
 _fixup_doc_links "${TARGET_DIR}/system/"*.html
+_fixup_search_link "${TARGET_DIR}/system/"*.html
+_disable_autocomplete "${TARGET_DIR}/system/"*.html
 
 mkdir "${TARGET_DIR}/apps"
 
@@ -71,6 +84,7 @@ for APP_VSN in ${APP_VSNS}; do
         cp -r "${SOURCE_DIR}/lib/${APP_VSN}/doc/html" "${TARGET_DIR}/apps/${APP}"
     fi
     _fixup_doc_links "${TARGET_DIR}/apps/${APP}/"*.html
+    _fixup_search_link "${TARGET_DIR}/apps/${APP}/"*.html
 done
 
 exit 0

--- a/assets/doc-search.tsx
+++ b/assets/doc-search.tsx
@@ -10,6 +10,8 @@ import ReactDOM from 'react-dom';
 
 import '@docsearch/css';
 
+declare var _docsearch_version: string;
+
 function getHTMLElement(
   value: string | HTMLElement,
   environment: DocSearchProps['environment'] = window
@@ -31,7 +33,7 @@ function Footer({ state }: {
 }): JSX.Element {
   return <>
     <footer>
-      <a href={"/doc/search?q=" + state.query}>
+      <a href={"/doc/search?v="+_docsearch_version+"q=" + state.query}>
         Show all {state.context.nbHits as number} results
       </a>
     </footer>
@@ -76,7 +78,7 @@ const docsearch = <DocSearch
   appId='LUYTU1J2MB'
   indexName='erlang' apiKey="86152ba1d4a9d7e179d537b8060a4c31"
   searchParameters={{
-    filters: 'docEngine:erl_docgen',
+    filters: 'version:'+_docsearch_version,
     attributesToRetrieve: [
       'hierarchy.lvl0',
       'hierarchy.lvl1',

--- a/docs.html
+++ b/docs.html
@@ -49,4 +49,8 @@ css: docs
         </div>
     </aside>
 </div>
+<script>
+{% assign majorReleases = site.releases | reverse | first %}
+_docsearch_version = "{{ majorReleases.release }}";
+</script>
 <script src="{{ '/assets/js/doc-search.bundle.js' | relative_url }}"></script>


### PR DESCRIPTION
This PR adds search for 26+27 and also adds some preparation for search in older versions. The search in 27 needs ex_doc v0.32.1 which was not used for rc3, so it will not be possible to test the new search until the final 27 release.