### PR TITLE
Fix canonical and redirect to html issues

### DIFF
--- a/_scripts/download-docs.sh
+++ b/_scripts/download-docs.sh
@@ -13,7 +13,7 @@ TOKEN=${2:-"token ${GITHUB_TOKEN}"}
 HDR=(--silent --location --fail --show-error -H "Authorization: ${TOKEN}" -H "X-GitHub-Api-Version: 2022-11-28")
 
 # The files that are involved when generating docs
-SCRIPT_FILES="_scripts/otp_flatten_docs _scripts/otp_doc_sitemap.sh"
+SCRIPT_FILES="_scripts/otp_flatten_docs _scripts/otp_flatten_ex_docs _scripts/otp_doc_sitemap.sh"
 
 _get_vsns() {
     grep "${1}" "${OTP_VERSIONS_TABLE}" | awk '{print $1}' | sed 's/OTP-\(.*\)/\1/g'

--- a/_scripts/otp_flatten_ex_docs
+++ b/_scripts/otp_flatten_ex_docs
@@ -67,18 +67,28 @@ _disable_autocomplete() {
     sed 's@\s*<title>@<meta name="exdoc:autocomplete" content="off">\n&@g' -i -- "$@"
 }
 
+_add_canonical() {
+    for file in "$@"; do
+        canonical=${file/#"${TARGET_DIR}/"}
+        sed 's@\s*<title>@<link rel="canonical" href="https://erlang.org/doc/'"${canonical}"'" />\n&@g' -i -- "${file}"
+    done
+}
+
+_flatten_and_update_docs() {
+    _fixup_doc_links "$@"
+    _fixup_search_link "$@"
+    _fixup_major_version "$@"
+    _add_canonical "$@"
+}
+
 mkdir "${TARGET_DIR}"
 
 cp -r "${SOURCE_DIR}/doc/"* "${TARGET_DIR}/"
-_fixup_doc_links "${TARGET_DIR}/"*.html
-_fixup_search_link "${TARGET_DIR}/"*.html
+_flatten_and_update_docs "${TARGET_DIR}/"*.html
 _disable_autocomplete "${TARGET_DIR}/"*.html
-_fixup_major_version "${TARGET_DIR}/"*.html
 cp -r "${SOURCE_DIR}/doc/system" "${TARGET_DIR}/system"
-_fixup_doc_links "${TARGET_DIR}/system/"*.html
-_fixup_search_link "${TARGET_DIR}/system/"*.html
+_flatten_and_update_docs "${TARGET_DIR}/system/"*.html
 _disable_autocomplete "${TARGET_DIR}/system/"*.html
-_fixup_major_version "${TARGET_DIR}/system/"*.html
 
 mkdir "${TARGET_DIR}/apps"
 
@@ -89,9 +99,7 @@ for APP_VSN in ${APP_VSNS}; do
     else
         cp -r "${SOURCE_DIR}/lib/${APP_VSN}/doc/html" "${TARGET_DIR}/apps/${APP}"
     fi
-    _fixup_doc_links "${TARGET_DIR}/apps/${APP}/"*.html
-    _fixup_search_link "${TARGET_DIR}/apps/${APP}/"*.html
-    _fixup_major_version "${TARGET_DIR}/apps/${APP}/"*.html
+    _flatten_and_update_docs "${TARGET_DIR}/apps/${APP}/"*.html
 done
 
 exit 0

--- a/_scripts/redirects.sh
+++ b/_scripts/redirects.sh
@@ -29,7 +29,6 @@ _redirect() {
     local FROM="$1"
     local TO="$2"
     if _check "$FROM" "$TO"; then
-        TO="${TO/%.html/}"
         echo "/doc/$FROM  /doc/$TO" | tr '[:upper:]' '[:lower:]'
         FROM="${FROM/%.html/}"
         echo "/doc/$FROM  /doc/$TO" | tr '[:upper:]' '[:lower:]'


### PR DESCRIPTION
This PR changes all redirects to be to .html version and also insert canonical URLs into all ex_doc html files.