### PR TITLE
otp27 highlights link fix

### DIFF
--- a/_releases/27.md
+++ b/_releases/27.md
@@ -1,7 +1,7 @@
 ---
 layout: release
 release: 27
-blog: _posts/2024-04-23-optimizations.md
+blog: _posts/2024-05-20-highlights-otp-27.md
 ---
 
 ## Documentation


### PR DESCRIPTION
I believe there is an error here. According to previous releases, it should point to "highlights" posts.