### PR TITLE
Make $erlang-grey darker

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,5 +1,5 @@
 $erlang-red: #a2003e;
-$erlang-grey: #424242;
+$erlang-grey: #202020;
 
 /* Configure bootstrap */
 $primary: $erlang-red;


### PR DESCRIPTION
The contrast of some parts of the code snippets in the homepage carousel was too low and didn't pass Lightouse accessibility check.

To check for accessibility issue using Lightouse (on chrome or chromium):

1. Open the inspector
2. Go to the `Lighthouse` tab
3. Select `Navigation (Default)`, `Mobile` or `Desktop`, `Accessibility`
4. Click `Analyze page load`

With this pr it should be 100 (it's only a subset of all the w3c rules, but it's something)