### PR TITLE
Fix homepage headings rank

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@ regenerate: true
 <div class="bg-erlang-grey">
     <div class="container banner px-0 px-md-2">
         <div class="slogan text-center">
-            <h4 class="px-4 pt-4 text-light">
+            <h1 class="h4 px-4 pt-4 text-light">
                 Practical functional programming<br /> for a parallel world
-            </h4>
+            </h1>
             <!-- <h4 class="px-4 pt-4 text-light">
                         Build massively scalable soft real-time systems
                     </h4> -->
@@ -70,7 +70,7 @@ regenerate: true
 </div>
 <main class="content container">
     <div class="what-is-erlang">
-        <h4>What is Erlang?</h4>
+        <h2 class="h4">What is Erlang?</h2>
         <p class="ps-3">Erlang is a programming language used to build massively scalable soft real-time
             systems with requirements on high availability. Some of its uses are in telecoms, banking,
             e-commerce, computer telephony and instant messaging. Erlang's runtime system has built-in
@@ -82,7 +82,7 @@ regenerate: true
         </a>
     </div>
     <div class="what-is-otp">
-        <h4>What is OTP?</h4>
+        <h2 class="h4">What is OTP?</h2>
         <p class="ps-3">OTP is set of Erlang libraries and design principles providing middle-ware to
             develop these systems. It includes its own distributed database, applications to interface
             towards other languages, debugging and release handling tools.</p>
@@ -93,12 +93,12 @@ regenerate: true
         </a>
     </div>
     <div class="news">
-        <h4>News</h4>
+        <h2 class="h4">News</h2>
         <dl class="ps-3">
             {% assign all_news = site.news | concat: site.posts | sort: "date" | reverse %}
             {% for news in all_news limit:3 %}
             <dt>
-                <h5><a href="{{ news.url | relative_url }}">{{ news.title }}</a></h5>
+                <h3 class="h5"><a href="{{ news.url | relative_url }}">{{ news.title }}</a></h3>
                 <small class="ps-2">{{ news.date | date: "%B %d, %Y" }} by {{ news.author }}</small>
             </dt>
             <dd class="px-3 py-1">
@@ -108,7 +108,7 @@ regenerate: true
         </dl>
     </div>
     <div class="participate">
-        <h4>Participate</h4>
+        <h2 class="h4">Participate</h2>
         <p class="ps-3">
             <a href="https://erlef.org"><img alt="Join the Erlang Ecosystem Foundation"
                     src="{{ '/assets/img/eef.png' | relative_url }}" class="img-fluid" width="174"></a>


### PR DESCRIPTION
Page headings should have a meaningful order [1]
tl:dr Start from h1 and make heach section heading a level up.

I fixed the homepage headings rank (a simple way to quickly see that is by using [2]).

To keep visual consistency I used bootstrap heading classes [3].

Cheers

--- 
[1]  https://www.w3.org/WAI/tutorials/page-structure/headings/#heading-ranks
[2]  https://accessibility.education.gov.uk/knowledge-hub/tools-testing/tools/headings-map
[3]  https://getbootstrap.com/docs/5.0/content/typography/#headings
