### PR TITLE
Correct date in OTP 28 RC4 news item

### DIFF
--- a/_news/179.md
+++ b/_news/179.md
@@ -4,7 +4,7 @@ id: 179
 title: "Erlang/OTP 28.0 Release Candidate 4"
 lead: "Erlang/OTP 28.0-rc4 is the fourth release candidate for OTP 28"
 tags: "release, OTP, 28.0-rc4, Release date"
-Candidate: "2025-05-05"
+date: "2025-05-05"
 author: "Björn Gustavsson"
 ---
 ## OTP 28.0-rc4


### PR DESCRIPTION
Looking at other news items (178, 177) it should be `date`, not `Candidate`.

I noticed this because every time you rebuild the site (https://github.com/erlang/erlang-org/actions), the timestamp in the RSS feed is set to the current date and time: http://www.erlang.org/rss/news

Example: `<updated>2025-05-08T07:29:53+00:00</updated>`