### PR TITLE
Remove Twitter links and meta keywords tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,14 +23,9 @@
     <meta property="og:image:secure_url" content="{{ '/assets/img/erlang-228x200.png' | absolute_url }}">
     <meta property="og:url" content="{{ '/' | absolute_url }}">
 
-    <!-- Twitter metadata -->
-    <meta name="twitter:card" content="summary" />
-    <meta property="twitter:title" content="Index" />
-    <meta name="twitter:site" content="@erlang_org" />
-
     <!-- Rich data for google search -->
     <script type="application/ld+json">
-{"@type":"WebSite","url":"https://erlang.org/","headline":"{{ title }}","name":"Erlang.org","sameAs":["https://twitter.com/erlang_org","https://github.com/erlang/otp"],"@context":"https://schema.org"}</script>
+{"@type":"WebSite","url":"https://erlang.org/","headline":"{{ title }}","name":"Erlang.org","sameAs":["https://github.com/erlang/otp"],"@context":"https://schema.org"}</script>
 
     <title>{{ title }}</title>
 
@@ -40,7 +35,6 @@
 
     <meta name="application-name" content="Erlang.org">
     <meta name="description" content="The official home of the Erlang Programming Language">
-    <meta name="keywords" content="Erlang programming language functional parallel distributed documentation download community">
     <!-- https://www.rssboard.org/rss-autodiscovery -->
     <link rel="alternate" type="application/atom+xml" title="News Atom Feed" href="{{ '/news.xml' | absolute_url }}" />
     <link rel="alternate" type="application/atom+xml" title="Blog Atom Feed" href="{{ '/blog.xml' | absolute_url }}" />
@@ -99,11 +93,6 @@
                     width="32" alt="Erlang/OTP rss feed"></a>
         </div>
         {% endif %}
-        <div>
-            <a href="http://www.twitter.com/erlang_org">
-                {% include svg-symbol.html symbol="twitter" title="Erlang/OTP twitter" width="32" height="27" %}
-            </a>
-        </div>
     </footer>
     <!-- SVG icons -->
     <svg xmlns="http://www.w3.org/2000/svg" width="0" height="0">


### PR DESCRIPTION
Title: Remove Twitter footer link and obsolete meta keywords tag

Body:

This PR addresses two cleanups in _layouts/default.html:

1. Remove Twitter footer link (closes #197)
As noted in #197, the @erlang_org Twitter account is no longer in use. This PR removes:

The Twitter icon and link from the footer
The <meta name="twitter:card">, twitter:title, and twitter:site tags from the head
The https://twitter.com/erlang_org entry from the JSON-LD sameAs array
2. Remove obsolete meta keywords tag (closes #196)
Modern search engines have not used the keywords meta tag for ranking in over a decade, and it is considered obsolete by current SEO best practices. Removing it keeps the HTML cleaner with no functional impact.

Changes
_layouts/default.html: