### PR TITLE
Improve inline search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUNDLE_PATH?=vendor/bundle
 
 build: setup
 	bundler exec jekyll build
-	npx purgecss --css _site/assets/css/*.css --content `find _site -name "*.html" -o -name "*.js" | grep -v _site/doc/ | grep -v _site/docs/`  -o _site/assets/css/
+	npx purgecss --css _site/assets/css/*.css --content `find _site -name "*.html" -o -name "*.js" | grep -v _site/doc/ | grep -v _site/docs/` --safelist '/^alg-/' -o _site/assets/css/
 
 netlify: clean
 	$(MAKE) -j $(shell nproc 2>/dev/null || sysctl -n hw.ncpu) --debug=basic BUNDLE_PATH=/opt/build/cache/bundle JEKYLL_ENV=production

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ test:
 	yamllint -f standard .
 	npm run shellcheck
 	_scripts/check.sh
+	_scripts/check_algolia_search.sh
 
 algolia:
 	_scripts/run_algolia_scraper.sh

--- a/_crawler.js
+++ b/_crawler.js
@@ -1,0 +1,709 @@
+new Crawler({
+  appId: "LUYTU1J2MB",
+  apiKey: "secret",
+  rateLimit: 8,
+  sitemaps: ["https://www.erlang.org/docs/sitemap_algolia.xml"],
+  cache: { enabled: false },
+  renderJavaScript: false,
+  ignoreCanonicalTo: true,
+  discoveryPatterns: [
+    "https://www.erlang.org/doc/**",
+    "https://www.erlang.org/docs/**",
+  ],
+  schedule: "at 20:40 on Tuesday",
+  actions: [
+    {
+      indexName: "erlang",
+      pathsToMatch: [
+        "https://www.erlang.org/doc/**",
+        "https://www.erlang.org/docs/**",
+      ],
+      recordExtractor: ({ $, url }) => {
+        try {
+          const generator = $("meta[name=generator]").attr("content");
+          const vsn = $("meta[name=major-vsn]").attr("content");
+          const root = url.pathname.startsWith("/doc/")
+            ? "/doc/"
+            : "/docs/" + vsn + "/";
+          console.log(url.pathname);
+          if (
+            url.pathname.match(
+              /(index|users_guide|notes|release_notes|api-reference.html|404|search|nyi|man_index)(\.html)?$/,
+            ) ||
+            !url.pathname.match(/\.html$/)
+          ) {
+            return [];
+          }
+          if (generator && generator.startsWith("ExDoc")) {
+            const collapseAndTrim = (/** @type {string} */ str) =>
+              str.replace(/[\s]+/g, " ").trim();
+            const assert = (
+              /** @type {boolean} */ condition,
+              /** @type {string} */ message,
+            ) => {
+              if (!condition) throw Error("Assert failed: " + (message || ""));
+            };
+
+            if ($('script:contains("window.location.replace")').length > 0) {
+              return [];
+            }
+
+            // @ts-ignore
+            const removeHtml = (elem) => {
+              return $("<div />")
+                .html(
+                  elem
+                    .toString()
+                    .replace(/<span class="sr-only">View Source<\/span>/g, "")
+                    .replace(/<span class="sr-only">Copy Markdown<\/span>/g, "")
+                    .replace(/<\/?[^>]+>/g, " ")
+                    .replace(/\s\s+/g, " ")
+                    .replace(/ ([.,])/g, "$1")
+                    .trim(),
+                )
+                .text();
+            };
+
+            console.log("Parsing as ExDoc: vsn=" + vsn);
+
+            let recs = []; // The records to return
+            let cnt = 0; // The number of records found do far
+            const app = collapseAndTrim($(".sidebar-projectName").text());
+            // Type can be "Application", "Command", "Module", "File",
+            //    "User's Guide"
+            let docType = $("body").attr("data-type");
+            if (docType == undefined) docType = $("main").attr("data-type");
+            if (docType == "extras") {
+              if (url.href.endsWith("_app")) {
+                docType = "Application";
+              } else if (url.href.endsWith("_cmd")) {
+                docType = "Command";
+              } else if (
+                $("a[title='View Source']")
+                  .attr("href")
+                  .match(/reference_manual/)
+              ) {
+                docType = "Erlang Reference Manual";
+              } else if (
+                $("a[title='View Source']")
+                  .attr("href")
+                  .match(/system\/doc/)
+              ) {
+                docType = "Erlang System Documentation";
+              } else {
+                docType = "User's Guide";
+              }
+            } else {
+              assert(docType == "modules");
+              docType = "Module";
+            }
+            const isUsersGuide = docType != "Module";
+            const mod = $("h1 > span").first().text();
+
+            console.log("docType:" + docType);
+
+            const createRecord = (props) => {
+              let level = 0;
+
+              props.content = collapseAndTrim(props.content).substring(
+                0,
+                90000,
+              );
+
+              console.log(props.content);
+
+              // Add null to all hierarchy properties that are not set
+              for (let i = 0; i < 7; i++) {
+                if (props.hierarchy.hasOwnProperty("lvl" + i)) {
+                  props.hierarchy["lvl" + i] = collapseAndTrim(
+                    props.hierarchy["lvl" + i],
+                  );
+                  level++;
+                } else {
+                  props.hierarchy["lvl" + i] = null;
+                }
+                if (props.hierarchy_radio.hasOwnProperty("lvl" + i)) {
+                  if (!Array.isArray(props.hierarchy_radio["lvl" + i])) {
+                    props.hierarchy_radio["lvl" + i] = [
+                      collapseAndTrim(props.hierarchy_radio["lvl" + i]),
+                    ];
+                  }
+                } else {
+                  props.hierarchy_radio["lvl" + i] = null;
+                }
+              }
+
+              assert(
+                props.anchor != undefined,
+                "anchor is undefined" + JSON.stringify(props.hierarchy),
+              );
+              if (docType != "Module") {
+                props.mfa = null;
+              }
+
+              if (props.namePrefixes === undefined) {
+                props.namePrefixes = null;
+              }
+              if (props.modNamePrefixes === undefined) {
+                props.modNamePrefixes = null;
+              }
+
+              return {
+                objectID: ++cnt + "-" + url + "#" + props.anchor,
+                version: vsn,
+                tags: [...new Set([docType, app])], // Use Set to remove duplicates
+                docEngine: "ex_doc",
+                docType,
+                app,
+                url: url + "#" + props.anchor,
+                url_without_variables: url + "#" + props.anchor,
+                url_without_anchor: url,
+                lang: "en",
+                type: "content", // Must be content
+                no_variables: false,
+                weight: {
+                  pageRank:
+                    app == "Erlang Reference Manual"
+                      ? "2"
+                      : docType == "User's Guide"
+                        ? "1"
+                        : "3",
+                  level,
+                  position: cnt,
+                },
+                isModule: props.isModule ? true : false, // This is used by the instantsearch frontend
+                hierarchy_camel: props.hierarchy,
+                hierarchy_radio_camel: props.hierarchy_radio,
+                ...props,
+              };
+            };
+
+            // push the module description
+            recs.push(
+              createRecord({
+                anchor: "",
+                content: removeHtml(
+                  isUsersGuide
+                    ? $("h1").nextUntil("h1, h2, h3, h4, h5")
+                    : $("#moduledoc").children().first().nextUntil("h2"), // $("#moduledoc"),
+                ),
+                hierarchy: {
+                  lvl0: app,
+                  lvl1: mod,
+                },
+                hierarchy_radio: {
+                  // We include the docType to the lvl1 radio in order to be able
+                  // to search for "ssl app", "config file" "erl command"
+                  lvl1: mod + " " + docType,
+                },
+                isModule: docType == "Module",
+                modNamePrefixes: docType == "Module" ? [mod] : [],
+                mfa: docType == "Module" ? mod : null,
+              }),
+            );
+
+            // push any functions
+            const funcs = $("section.detail");
+            let allAnchors = [];
+            funcs.each((i, fun) => {
+              // If an id is already used, we use the gh-id
+              // This type of anchor exists for example in system_info-1
+              let anchor = fun.attribs["id"];
+              allAnchors.push(anchor);
+
+              // name is the full name, i.e. map(Fun, List) -> List
+              const name = $(".signature", fun).text().trim();
+              // onlyName is the function name, i.e. map
+              const onlyName = name.split("(")[0].trim();
+
+              // https://www.algolia.com/doc/guides/managing-results/optimize-search-results/override-search-engine-defaults/how-to/how-can-i-make-queries-within-the-middle-of-a-word/
+              let onlyNamePrefixes = [];
+              for (let j = 0; j < onlyName.length; j++) {
+                onlyNamePrefixes.push(onlyName.slice(j));
+              }
+              const modNamePrefixes = onlyNamePrefixes.map(
+                (str) => mod + ":" + str,
+              );
+
+              let dochtml = $(".docstring", fun);
+              $(".specs", dochtml).remove();
+              $(".note", dochtml).remove();
+              const docstring = removeHtml(dochtml);
+
+              // the gl module has more than 1000 functions, so we any function that is an equiv
+              if (mod == "gl" && docstring.match(/^Equivalent/)) {
+                return;
+              }
+
+              recs.push(
+                createRecord({
+                  anchor,
+                  content: docstring,
+                  hierarchy: {
+                    lvl0: app,
+                    lvl1: mod,
+                    lvl2: name,
+                  },
+                  hierarchy_radio: {
+                    // For functions we add mod:name as the lvl1 radio hierachy
+                    // so that we raise the ranking of functions
+                    lvl1: mod + ":" + onlyName,
+                    lvl2: name,
+                  },
+                  namePrefixes: onlyNamePrefixes,
+                  modNamePrefixes,
+                  mfa: mod + ":" + onlyName,
+                  isModule: true,
+                }),
+              );
+            });
+
+            // Extract all h2 sections from a .md or moduledoc
+            let sections = [];
+            (isUsersGuide ? $("#top-content") : $("#moduledoc"))
+              .children("h2")
+              .each((index, element) => {
+                const header = $(element);
+                const nextElements = $(element).nextUntil("h2");
+                sections.push({ title: header, content: nextElements });
+              });
+
+            const parseDefinitionList = (
+              content,
+              titleId,
+              hierarchy,
+              level,
+            ) => {
+              const dls = [];
+              content.filter("ul").each((i, ul) => {
+                const maybeP = $(ul).children().first().children().first();
+                if (maybeP[0] && maybeP[0].name == "p") {
+                  const maybeStrong = maybeP.children().first();
+                  if (maybeStrong[0] && maybeStrong[0].name == "strong") {
+                    dls.push($(ul));
+                  }
+                }
+              });
+              if (dls.length > 0) {
+                dls.forEach((e) => {
+                  const ul = e;
+                  ul.children().each((i, li) => {
+                    const anchor =
+                      $(li).find("[id]").length == 0
+                        ? titleId
+                        : $(li).find("[id]").first().attr("id");
+                    const dt = removeHtml(
+                      $("p:first-child > strong:first-child", li),
+                    );
+                    recs.push(
+                      createRecord({
+                        anchor: anchor,
+                        content: removeHtml($(li)),
+                        hierarchy: { [level]: dt, ...hierarchy },
+                        hierarchy_radio: { [level]: dt },
+                      }),
+                    );
+                  });
+                });
+                return dls[0].prevUntil("h2, h3");
+              } else {
+                return content;
+              }
+            };
+
+            // Here we parse each section in app/com/file
+            sections.forEach(({ title, content }, i) => {
+              const titleText = removeHtml($("h2 > span", title));
+              const titleId = title.attr("id");
+              const mainContent = content.first().nextUntil("h2, h3").addBack();
+              const mainContentBeforeList = parseDefinitionList(
+                mainContent,
+                titleId,
+                { lvl0: app, lvl1: mod, lvl2: titleText },
+                "lvl3",
+              );
+
+              recs.push(
+                createRecord({
+                  anchor: titleId,
+                  content: removeHtml(mainContentBeforeList),
+                  hierarchy: {
+                    lvl0: app,
+                    lvl1: mod,
+                    lvl2: titleText,
+                  },
+                  hierarchy_radio: {
+                    lvl2: titleText,
+                  },
+                }),
+              );
+              content.next("h3").each((i, subsection) => {
+                const subContent = $(subsection).nextUntil("h3");
+                const subtitleText = removeHtml(
+                  $("h3 > span", $(subsection).first()),
+                );
+                const subtitleId = $(subsection).first().attr("id");
+                const subContentBeforeList = parseDefinitionList(
+                  subContent,
+                  subtitleId,
+                  { lvl0: app, lvl1: mod, lvl2: titleText, lvl3: subtitleText },
+                  "lvl4",
+                );
+
+                recs.push(
+                  createRecord({
+                    anchor: subtitleId,
+                    content: removeHtml(subContentBeforeList),
+                    hierarchy: {
+                      lvl0: app,
+                      lvl1: mod,
+                      lvl2: titleText,
+                      lvl3: subtitleText,
+                    },
+                    hierarchy_radio: {
+                      lvl3: subtitleText,
+                    },
+                  }),
+                );
+              });
+            });
+            return recs;
+          } else {
+            /* Crawl erl_docgen starts here */
+            const collapseAndTrim = (str) => str.replace(/[\s]+/g, " ").trim();
+            const assert = (condition, message) => {
+              if (!condition) throw Error("Assert failed: " + (message || ""));
+            };
+
+            let recs = []; // The records to return
+            let cnt = 0; // The number of records found do far
+            const app = collapseAndTrim($(".section-title").text());
+            // Type can be "Application", "Command", "Module", "File",
+            //    "User's Guide"
+            const docType =
+              $(".section-subtitle").text() == "User's Guide"
+                ? "User's Guide"
+                : $(".section-subtitle").text() == "Internal Documentation"
+                  ? "Internal Documentation"
+                  : $("#content h3 .title-name").html();
+            const isUsersGuide =
+              docType == "User's Guide" || docType == "Internal Documentation";
+            const mod = isUsersGuide
+              ? $(".innertube h1")
+                  .text()
+                  .replace(/^[0-9.]+/, "")
+              : $(".innertube h1").text();
+
+            const createRecord = (props) => {
+              let level = 0;
+
+              props.content = collapseAndTrim(props.content);
+
+              // Add null to all hierarchy properties that are not set
+              for (let i = 0; i < 7; i++) {
+                if (props.hierarchy.hasOwnProperty("lvl" + i)) {
+                  props.hierarchy["lvl" + i] = collapseAndTrim(
+                    props.hierarchy["lvl" + i],
+                  );
+                  level++;
+                } else {
+                  props.hierarchy["lvl" + i] = null;
+                }
+                if (props.hierarchy_radio.hasOwnProperty("lvl" + i)) {
+                  if (!Array.isArray(props.hierarchy_radio["lvl" + i])) {
+                    props.hierarchy_radio["lvl" + i] = [
+                      collapseAndTrim(props.hierarchy_radio["lvl" + i]),
+                    ];
+                  }
+                } else {
+                  props.hierarchy_radio["lvl" + i] = null;
+                }
+              }
+
+              assert(
+                props.anchor != undefined,
+                "anchor is undefined" + JSON.stringify(props.hierarchy),
+              );
+              if (docType != "Module") {
+                props.mfa = null;
+              }
+
+              if (props.namePrefixes === undefined) {
+                props.namePrefixes = null;
+              }
+              if (props.modNamePrefixes === undefined) {
+                props.modNamePrefixes = null;
+              }
+
+              return {
+                objectID: ++cnt + "-" + url + "#" + props.anchor,
+                version: vsn,
+                tags: [...new Set([docType, app])], // Use Set to remove duplicates
+                docEngine: "erl_docgen",
+                docType,
+                app,
+                url: url + "#" + props.anchor,
+                url_without_variables: url + "#" + props.anchor,
+                url_without_anchor: url,
+                lang: "en",
+                type: "content", // Must be content
+                no_variables: false,
+                weight: {
+                  pageRank:
+                    app == "Erlang Reference Manual"
+                      ? "2"
+                      : docType == "User's Guide"
+                        ? "1"
+                        : "3",
+                  level,
+                  position: cnt,
+                },
+                isModule: props.isModule ? true : false, // This is used by the instantsearch frontend
+                hierarchy_camel: props.hierarchy,
+                hierarchy_radio_camel: props.hierarchy_radio,
+                ...props,
+              };
+            };
+
+            // push the module description
+            recs.push(
+              createRecord({
+                anchor: "",
+                content: isUsersGuide
+                  ? $("#content h1").nextUntil("h1, h2, h3, h4, h5").text()
+                  : $(".description-body").text(),
+                hierarchy: {
+                  lvl0: app,
+                  lvl1: mod,
+                },
+                hierarchy_radio: {
+                  // We include the docType to the lvl1 radio in order to be able
+                  // to search for "ssl app", "config file" "erl command"
+                  lvl1: mod + " " + docType,
+                },
+                isModule: docType == "Module",
+                modNamePrefixes: docType == "Module" ? [mod] : [],
+                mfa: docType == "Module" ? mod : null,
+              }),
+            );
+
+            // push any functions
+            const funcs = $(".func h4");
+            let allAnchors = [];
+            funcs.each((i, fun) => {
+              // If an id is already used, we use the gh-id
+              // This type of anchor exists for example in system_info-1
+              let anchor = fun.attribs["id"];
+              if (allAnchors.findIndex((i) => i == anchor) != -1) {
+                anchor = $(".ghlink-before", fun).attr("id");
+              }
+              allAnchors.push(anchor);
+
+              // name is the full name, i.e. map(Fun, List) -> List
+              const name = $(".title-name", fun).text().trim();
+              // onlyName is the function name, i.e. map
+              const onlyName = name.split("(")[0].trim();
+
+              // the gl module has more than 1000 functions, so we remove functions
+              // without documentation or if they end in ARB.
+              if (
+                mod == "gl" &&
+                ($(fun).next().is("h4") || onlyName.endsWith("ARB")) &&
+                !onlyName.match(/^'?begin/)
+              ) {
+                return;
+              }
+
+              // https://www.algolia.com/doc/guides/managing-results/optimize-search-results/override-search-engine-defaults/how-to/how-can-i-make-queries-within-the-middle-of-a-word/
+              let onlyNamePrefixes = [];
+              for (i = 0; i < onlyName.length; i++) {
+                onlyNamePrefixes.push(onlyName.slice(i));
+              }
+              const modNamePrefixes = onlyNamePrefixes.map(
+                (str) => mod + ":" + str,
+              );
+
+              recs.push(
+                createRecord({
+                  anchor,
+                  content: $(fun)
+                    .closest("article")
+                    .find(".exports-tube")
+                    .text(),
+                  hierarchy: {
+                    lvl0: app,
+                    lvl1: mod,
+                    lvl2: name,
+                  },
+                  hierarchy_radio: {
+                    // For functions we add mod:name as the lvl1 radio hierachy
+                    // so that we raise the ranking of functions
+                    lvl1: mod + ":" + onlyName,
+                    lvl2: name,
+                  },
+                  namePrefixes: onlyNamePrefixes,
+                  modNamePrefixes,
+                  mfa: mod + ":" + onlyName,
+                  isModule: true,
+                }),
+              );
+            });
+
+            // Here we parse each section in app/com/file
+            const sections = $("section.innertube");
+            sections.each((i, section) => {
+              const dl = $(".REFBODY dl", section);
+
+              // if we don't find any definition list
+              // we just add the entire section to the search
+              if (dl.length == 0) {
+                recs.push(
+                  createRecord({
+                    anchor: $("h3", section).attr("id"),
+                    content: $(".REFBODY", section).text(),
+                    hierarchy: {
+                      lvl0: app,
+                      lvl1: mod,
+                      lvl2: $(".title-name", section).text(),
+                    },
+                    hierarchy_radio: {
+                      lvl2: $(".title-name", section).text(),
+                    },
+                  }),
+                );
+              } else {
+                // If we do find a definition list
+                // we add each item as a record to the search
+                $("dt", dl).each((i, dt) => {
+                  const anchor =
+                    $(dt).find("[name]").length == 0
+                      ? $("h3", section).attr("id")
+                      : $(dt).find("[name]").first().attr("name");
+                  recs.push(
+                    createRecord({
+                      anchor: anchor,
+                      content: $(dt).next("dd").text(),
+                      hierarchy: {
+                        lvl0: app,
+                        lvl1: mod,
+                        lvl2: $(".title-name", section).text(),
+                        lvl3: $(dt).text(),
+                      },
+                      hierarchy_radio: {
+                        lvl3: $(dt).text(),
+                      },
+                    }),
+                  );
+                });
+              }
+            });
+
+            // Here we parse sections in User's Guides
+            $(".innertube h3").each((i, section) => {
+              recs.push(
+                createRecord({
+                  anchor: $(section).attr("id"),
+                  content: $(section).nextUntil("h3, h4").text(),
+                  hierarchy: {
+                    lvl0: app,
+                    lvl1: mod,
+                    lvl2: $(".title-name", section)
+                      .text()
+                      .replace(/^[0-9.]*/, ""),
+                  },
+                  hierarchy_radio: {
+                    lvl2: $(".title-name", section)
+                      .text()
+                      .replace(/^[0-9.]*/, ""),
+                  },
+                }),
+              );
+              let subSection = $(section).nextUntil("h3, h4").last().next();
+              while (subSection.is("h4")) {
+                recs.push(
+                  createRecord({
+                    anchor: $(subSection).attr("id"),
+                    content: $(subSection).nextUntil("h3, h4").text(),
+                    hierarchy: {
+                      lvl0: app,
+                      lvl1: mod,
+                      lvl2: $(".title-name", section)
+                        .text()
+                        .replace(/^[0-9.]*/, ""),
+                      lvl3: $(".title-name", subSection).text(),
+                    },
+                    hierarchy_radio: {
+                      lvl3: $(".title-name", subSection).text(),
+                    },
+                  }),
+                );
+                subSection = $(subSection).nextUntil("h3, h4").last().next();
+              }
+            });
+
+            return recs;
+          }
+        } catch (e) {
+          console.log(e.stack);
+          return [];
+        }
+      },
+    },
+  ],
+  initialIndexSettings: {
+    erlang: {
+      attributesForFaceting: ["type", "lang"],
+      attributesToRetrieve: ["hierarchy", "content", "anchor", "url"],
+      attributesToHighlight: ["hierarchy", "hierarchy_camel", "content"],
+      attributesToSnippet: ["content:10"],
+      camelCaseAttributes: ["hierarchy", "hierarchy_radio", "content"],
+      searchableAttributes: [
+        "unordered(hierarchy_radio_camel.lvl1)",
+        "unordered(hierarchy_radio.lvl1)",
+        "hierarchy_radio_camel.lvl2",
+        "hierarchy_radio.lvl2",
+        "unordered(hierarchy_radio_camel.lvl0)",
+        "unordered(hierarchy_radio.lvl0)",
+        "unordered(hierarchy_radio_camel.lvl3)",
+        "unordered(hierarchy_radio.lvl3)",
+        "unordered(hierarchy_camel.lvl0)",
+        "unordered(hierarchy.lvl0)",
+        "unordered(hierarchy_camel.lvl1)",
+        "unordered(hierarchy.lvl1)",
+        "unordered(hierarchy_camel.lvl2)",
+        "unordered(hierarchy.lvl2)",
+        "unordered(hierarchy_camel.lvl3)",
+        "unordered(hierarchy.lvl3)",
+        "content",
+      ],
+      distinct: true,
+      attributeForDistinct: "url",
+      customRanking: [
+        "desc(weight.pageRank)",
+        "desc(weight.level)",
+        "asc(weight.position)",
+      ],
+      ranking: [
+        "words",
+        "filters",
+        "typo",
+        "attribute",
+        "proximity",
+        "exact",
+        "custom",
+      ],
+      highlightPreTag: '<span class="algolia-docsearch-suggestion--highlight">',
+      highlightPostTag: "</span>",
+      minWordSizefor1Typo: 3,
+      minWordSizefor2Typos: 7,
+      allowTyposOnNumericTokens: false,
+      minProximity: 1,
+      ignorePlurals: true,
+      queryLanguages: ["en"],
+      advancedSyntax: true,
+      attributeCriteriaComputedByMinProximity: true,
+      removeWordsIfNoResults: "allOptional",
+      separatorsToIndex: "",
+    },
+  },
+});

--- a/_crawler.js
+++ b/_crawler.js
@@ -50,12 +50,24 @@ new Crawler({
 
             // @ts-ignore
             const removeHtml = (elem) => {
+              let html = elem
+                .toString()
+                .replace(/<span class="sr-only">View Source<\/span>/g, "")
+                .replace(/<span class="sr-only">Copy Markdown<\/span>/g, "");
+              // ExDoc wraps each code token in its own <span> for
+              // syntax highlighting. The generic space-replacement
+              // below would otherwise turn `lists:foreach(Fun, List)`
+              // into `lists : foreach ( Fun, List )` in the indexed
+              // content and snippets. Strip tags inside <code> and
+              // <pre> without inserting whitespace first.
+              html = html.replace(
+                /<(code|pre)([^>]*)>([\s\S]*?)<\/\1>/g,
+                (_, tag, attrs, inner) =>
+                  `<${tag}${attrs}>${inner.replace(/<\/?[^>]+>/g, "")}</${tag}>`,
+              );
               return $("<div />")
                 .html(
-                  elem
-                    .toString()
-                    .replace(/<span class="sr-only">View Source<\/span>/g, "")
-                    .replace(/<span class="sr-only">Copy Markdown<\/span>/g, "")
+                  html
                     .replace(/<\/?[^>]+>/g, " ")
                     .replace(/\s\s+/g, " ")
                     .replace(/ ([.,])/g, "$1")
@@ -98,7 +110,13 @@ new Crawler({
               docType = "Module";
             }
             const isUsersGuide = docType != "Module";
-            const mod = $("h1 > span").first().text();
+            // Module pages emit `<h1><span>name</span> <small>vsn</small></h1>`
+            // so `h1 > span` is the right selector. User guides,
+            // command pages and system docs emit a plain `<h1>Title</h1>`
+            // with no inner span — fall through to the bare h1 text.
+            const mod = isUsersGuide
+              ? collapseAndTrim($("h1").first().text())
+              : $("h1 > span").first().text();
 
             console.log("docType:" + docType);
 
@@ -109,6 +127,14 @@ new Crawler({
                 0,
                 90000,
               );
+
+              // Skip section/anchor records that ended up with no
+              // narrative text. They show up in results as
+              // no-excerpt hits that just jump to a heading. The
+              // module-overview record (anchor === "") is kept even
+              // with empty content because the page itself is the
+              // landing target.
+              if (props.anchor !== "" && props.content === "") return null;
 
               console.log(props.content);
 
@@ -148,6 +174,20 @@ new Crawler({
                 props.modNamePrefixes = null;
               }
 
+              // Derive what the record points at, from the URL
+              // anchor: `t:foo/0` -> type, `c:foo/2` -> callback,
+              // anything else inside a module page -> function.
+              // null for module-overview records and for sections in
+              // guides/commands/system docs.
+              let kind = null;
+              if (props.isModule && props.anchor) {
+                if (props.anchor.startsWith("t:")) kind = "type";
+                else if (props.anchor.startsWith("c:")) kind = "callback";
+                else kind = "function";
+              }
+
+              const anchorSuffix = props.anchor ? "#" + props.anchor : "";
+
               return {
                 objectID: ++cnt + "-" + url + "#" + props.anchor,
                 version: vsn,
@@ -155,8 +195,9 @@ new Crawler({
                 docEngine: "ex_doc",
                 docType,
                 app,
-                url: url + "#" + props.anchor,
-                url_without_variables: url + "#" + props.anchor,
+                kind,
+                url: url + anchorSuffix,
+                url_without_variables: url + anchorSuffix,
                 url_without_anchor: url,
                 lang: "en",
                 type: "content", // Must be content
@@ -179,14 +220,27 @@ new Crawler({
             };
 
             // push the module description
+            let overviewContent = removeHtml(
+              isUsersGuide
+                ? $("h1").nextUntil("h1, h2, h3, h4, h5")
+                : $("#moduledoc").children().first().nextUntil("h2"),
+            );
+            // Reference-manual chapter pages and similar user-guide
+            // pages put their h1 immediately before an h2, so the
+            // gap above contains only ExDoc's action links
+            // (Copy Markdown / View Source) which `removeHtml`
+            // strips to nothing. Fall back to the first paragraph
+            // of the first h2 section so the overview record has a
+            // useful excerpt instead of just the title.
+            if (isUsersGuide && !overviewContent) {
+              overviewContent = removeHtml(
+                $("#top-content").find("h2").first().next("p"),
+              );
+            }
             recs.push(
               createRecord({
                 anchor: "",
-                content: removeHtml(
-                  isUsersGuide
-                    ? $("h1").nextUntil("h1, h2, h3, h4, h5")
-                    : $("#moduledoc").children().first().nextUntil("h2"), // $("#moduledoc"),
-                ),
+                content: overviewContent,
                 hierarchy: {
                   lvl0: app,
                   lvl1: mod,
@@ -295,10 +349,19 @@ new Crawler({
                     const dt = removeHtml(
                       $("p:first-child > strong:first-child", li),
                     );
+                    // Drop the dt+separator from the indexed
+                    // content so it isn't duplicated with
+                    // hierarchy.lvl3. Clone first to leave the
+                    // original DOM intact for downstream
+                    // extractors.
+                    const $body = $(li).clone();
+                    $body.find("p:first-child > strong:first-child").remove();
+                    const content = removeHtml($body)
+                      .replace(/^[\s\-–—:]+/, "");
                     recs.push(
                       createRecord({
                         anchor: anchor,
-                        content: removeHtml($(li)),
+                        content: content,
                         hierarchy: { [level]: dt, ...hierarchy },
                         hierarchy_radio: { [level]: dt },
                       }),
@@ -367,7 +430,9 @@ new Crawler({
                 );
               });
             });
-            return recs;
+            // createRecord returns null for empty-content section
+            // records; drop them here so callers don't have to.
+            return recs.filter((r) => r !== null);
           } else {
             /* Crawl erl_docgen starts here */
             const collapseAndTrim = (str) => str.replace(/[\s]+/g, " ").trim();
@@ -652,7 +717,11 @@ new Crawler({
   ],
   initialIndexSettings: {
     erlang: {
-      attributesForFaceting: ["type", "lang"],
+      // `kind` ('function' | 'type' | 'callback') is derived per
+      // record from the URL anchor — facetable so /doc/search.html
+      // can offer it as a filter. `type` is dead-weight (every
+      // record hardcodes "content").
+      attributesForFaceting: ["kind", "lang"],
       attributesToRetrieve: ["hierarchy", "content", "anchor", "url"],
       attributesToHighlight: ["hierarchy", "hierarchy_camel", "content"],
       attributesToSnippet: ["content:10"],

--- a/_scripts/add_dl_anchors.js
+++ b/_scripts/add_dl_anchors.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+//
+// Add synthetic anchors to definition-list items that don't have
+// one. ExDoc renders markdown definition lists as:
+//
+//   <ul>
+//     <li>
+//       <p><strong><code class="inline">term</code></strong> - description</p>
+//     </li>
+//     ...
+//   </ul>
+//
+// Some OTP source pages add explicit anchors via markdown attribute
+// lists (kramdown `{: #id }`), ending up as <code id="..."> in HTML.
+// Others don't. Without an id, the crawler's parseDefinitionList
+// falls back to the parent section's titleId, so every dl-item in
+// the section collapses to the same URL. Deep links from search
+// land on the section header rather than the specific item.
+//
+// This script walks every HTML page under <docs-dir>, finds the
+// ExDoc dl pattern, and for each item without an existing id
+// injects one onto the <code> (or onto the <strong> when no
+// <code> is present) using a slug of the dt text. Collisions
+// within a page get a numeric suffix. Idempotent: items that
+// already carry an id are skipped.
+//
+// Regex-based instead of cheerio-based so the rewrite is purely
+// additive — the rest of the file stays byte-identical, which
+// keeps git diffs reviewable. ExDoc's HTML for dl items is
+// uniform enough that the regex approach is reliable.
+//
+// The crawler picks the injected id up naturally via
+// $(li).find("[id]") with no change on its side.
+//
+// Usage: node _scripts/add_dl_anchors.js <docs-dir>
+
+const fs = require("fs");
+const path = require("path");
+
+function slugify(s) {
+  return s
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    // Keep +, _, - so anchors like +pad, c_node, M_cp survive
+    // intact, matching ExDoc's own slug convention.
+    .replace(/[^a-z0-9+_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function processFile(file) {
+  const original = fs.readFileSync(file, "utf8");
+
+  // Pre-seed the id collision set with every existing id in the
+  // file (headings, links, ExDoc-added dl ids, etc.) so we never
+  // shadow something that's already in use.
+  const used = new Set();
+  for (const m of original.matchAll(/\bid="([^"]+)"/g)) used.add(m[1]);
+
+  const alloc = (base) => {
+    let id = base;
+    let n = 2;
+    while (used.has(id)) id = `${base}-${n++}`;
+    used.add(id);
+    return id;
+  };
+
+  let changes = 0;
+
+  // Pattern 1: dl-item with inner <code>, no id yet. The negative
+  // lookahead on attrs catches `<code class="inline">`, but not
+  // `<code class="inline" id="...">`.
+  let out = original.replace(
+    /<li>(\s*)<p>(\s*)<strong>(\s*)<code((?:\s+(?!id=)[a-z-]+="[^"]*")*)>([^<]+)<\/code>/g,
+    (full, ws1, ws2, ws3, attrs, term) => {
+      const slug = slugify(term.trim());
+      if (!slug) return full;
+      const id = alloc(slug);
+      changes++;
+      return `<li>${ws1}<p>${ws2}<strong>${ws3}<code${attrs} id="${id}">${term}</code>`;
+    },
+  );
+
+  // Pattern 2: dl-item with plain <strong> (no inner <code>).
+  // Pattern 1 already handled the inner-code case, so this only
+  // fires on remaining bare-strong dl-items.
+  out = out.replace(
+    /<li>(\s*)<p>(\s*)<strong>([^<]+)<\/strong>/g,
+    (full, ws1, ws2, term) => {
+      const slug = slugify(term.trim());
+      if (!slug) return full;
+      const id = alloc(slug);
+      changes++;
+      return `<li>${ws1}<p>${ws2}<strong id="${id}">${term}</strong>`;
+    },
+  );
+
+  if (changes > 0) fs.writeFileSync(file, out);
+  return changes;
+}
+
+function walk(dir, out = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (e.isFile() && p.endsWith(".html")) out.push(p);
+  }
+  return out;
+}
+
+const docsDir = process.argv[2];
+if (!docsDir) {
+  console.error("usage: node add_dl_anchors.js <docs-dir>");
+  process.exit(1);
+}
+
+const files = walk(docsDir);
+let totalChanges = 0;
+let filesChanged = 0;
+for (const f of files) {
+  const n = processFile(f);
+  if (n > 0) {
+    filesChanged++;
+    totalChanges += n;
+  }
+}
+console.log(
+  `Added ${totalChanges} dl anchors across ${filesChanged}/${files.length} files`,
+);

--- a/_scripts/check_algolia_search.sh
+++ b/_scripts/check_algolia_search.sh
@@ -305,12 +305,12 @@ _check_overview_content() {
 }
 _check_overview_content "/system/typespec.html" \
     "Erlang is a dynamically typed language" \
-    "Erlang System Documentation" "typespec types"
+    "Erlang System Documentation" "types function specifications"
 _check_overview_content "/system/modules.html" \
     "Erlang code is divided into" \
     "Erlang System Documentation" "modules"
 _check_overview_content "/system/ref_man_functions.html" \
-    "A function clause consists of" \
+    "A function declaration is a sequence of function clauses" \
     "Erlang System Documentation" "function declaration"
 
 # 5. Searching "reference manual" must surface multiple chapter

--- a/_scripts/check_algolia_search.sh
+++ b/_scripts/check_algolia_search.sh
@@ -94,6 +94,369 @@ for test in "${TESTS[@]}"; do
     printf '  \033[32mOK\033[0m   %-60s -> %s\n' "$label" "$expected_url"
 done
 
+# Crawler-shape regression checks. Each one targets a specific
+# breakage the crawler is supposed to prevent. See _crawler.js.
+#
+# These currently FAIL — they encode bugs we plan to fix in the
+# crawler. They flip green automatically on the next crawl after
+# _crawler.js is redeployed.
+
+_algolia_query() {
+    local filter="$1" query="$2" count="${3:-10}"
+    curl -fsS -X POST \
+        "https://${APP_ID}-dsn.algolia.net/1/indexes/${INDEX}/query" \
+        -H "X-Algolia-Application-Id: ${APP_ID}" \
+        -H "X-Algolia-API-Key: ${API_KEY}" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg q "$query" --arg f "$filter" --argjson n "$count" \
+                '{query: $q, filters: $f, hitsPerPage: $n, analytics: false}')"
+}
+
+_report() {
+    local ok="$1" label="$2" detail="$3"
+    if [ "$ok" = "1" ]; then
+        PASS=$((PASS + 1))
+        printf '  \033[32mOK\033[0m   %-60s -> %s\n' "$label" "$detail"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  \033[31mFAIL\033[0m %-60s -> %s\n' "$label" "$detail"
+    fi
+}
+
+# Helpers used by several test groups below.
+
+_check_present() {
+    local path="$1" query="$2" appname="$3"
+    resp=$(_algolia_query "version:${VERSION} AND app:\"$appname\"" "$query")
+    found=$(echo "$resp" | jq -r --arg u "$path" \
+        '[.hits[] | select(.url | contains($u))] | length')
+    if [ "$found" -gt 0 ]; then
+        _report 1 "[crawler] indexed ${path}" "present"
+    else
+        _report 0 "[crawler] indexed ${path}" "missing"
+    fi
+}
+
+_check_lvl2() {
+    # Use endswith rather than contains so that paths like
+    # `#enif_alloc` don't accidentally match `#enif_alloc_binary`.
+    local path="$1" expected_prefix="$2" appname="$3" query="$4"
+    resp=$(_algolia_query "version:${VERSION} AND app:\"$appname\"" "$query")
+    got=$(echo "$resp" | jq -r --arg u "$path" \
+        '.hits[] | select(.url | endswith($u)) | .hierarchy.lvl2' | head -1)
+    if [[ "$got" == "$expected_prefix"* ]]; then
+        _report 1 "[crawler] lvl2 ${path}" "${got}"
+    else
+        _report 0 "[crawler] lvl2 ${path}" "got '${got}', want prefix '${expected_prefix}'"
+    fi
+}
+
+_check_lvl3() {
+    local path="$1" expected_prefix="$2" appname="$3" query="$4"
+    resp=$(_algolia_query "version:${VERSION} AND app:\"$appname\"" "$query")
+    got=$(echo "$resp" | jq -r --arg u "$path" \
+        '.hits[] | select(.url | contains($u)) | .hierarchy.lvl3' | head -1)
+    if [[ "$got" == "$expected_prefix"* ]]; then
+        _report 1 "[crawler] lvl3 ${path}" "${got}"
+    else
+        _report 0 "[crawler] lvl3 ${path}" "got '${got}', want prefix '${expected_prefix}'"
+    fi
+}
+
+_check_content_prefix() {
+    local path="$1" expected_prefix="$2" appname="$3" query="$4"
+    resp=$(_algolia_query "version:${VERSION} AND app:\"$appname\"" "$query")
+    got=$(echo "$resp" | jq -r --arg u "$path" \
+        '.hits[] | select(.url | contains($u)) | .content' | head -1)
+    if [[ "$got" == "$expected_prefix"* ]]; then
+        _report 1 "[crawler] content-prefix ${path}" "starts with '${expected_prefix}'"
+    else
+        _report 0 "[crawler] content-prefix ${path}" \
+            "got '$(printf "%s" "$got" | head -c 60)', want prefix '${expected_prefix}'"
+    fi
+}
+
+# 1. Module-overview URLs must not have a trailing '#'.
+#    `lists.html#` is ugly in the address bar after click-through.
+#    Algolia rejects filter-only (empty-query) requests, so we
+#    query for the module name and pick the overview hit by URL
+#    shape.
+for mod in lists gen_server ssl crypto; do
+    case "$mod" in
+        ssl|crypto) app="$mod" ;;
+        *)          app="stdlib" ;;
+    esac
+    resp=$(_algolia_query "version:${VERSION} AND app:\"${app}\"" "$mod")
+    overview_url=$(echo "$resp" | jq -r --arg m "${mod}.html" \
+        '.hits[] | select(.url | endswith($m) or endswith($m + "#")) | .url' \
+        | head -1)
+    if [ -z "$overview_url" ]; then
+        _report 0 "[crawler] no-trailing-# ${mod}" "no module-overview record found"
+    elif [[ "$overview_url" == *# ]]; then
+        _report 0 "[crawler] no-trailing-# ${mod}" "got ${overview_url}"
+    else
+        _report 1 "[crawler] no-trailing-# ${mod}" "${overview_url}"
+    fi
+done
+
+# 2. Code tokens in indexed content must not be space-separated by
+#    the syntax-highlight <span> teardown. We look for the mangled
+#    pattern `mod : func` adjacent to the unmangled `mod:func`
+#    appearing nowhere — testing absence of the mangled form is the
+#    simpler invariant.
+for pair in "lists|append" "lists|subtract" "ssl|connect" "ets|new"; do
+    mod="${pair%|*}"; func="${pair#*|}"
+    case "$mod" in
+        ssl) app="ssl" ;;
+        *)   app="stdlib" ;;
+    esac
+    resp=$(_algolia_query "version:${VERSION} AND app:\"${app}\"" "${mod}:${func}")
+    mangled=$(echo "$resp" | jq -r --arg p "${mod} : ${func}" \
+        '[.hits[] | select(.content != null and (.content | contains($p)))] | length')
+    if [ "$mangled" = "0" ]; then
+        _report 1 "[crawler] unmangled-code ${mod}:${func}" "no '${mod} : ${func}' in any hit"
+    else
+        _report 0 "[crawler] unmangled-code ${mod}:${func}" \
+            "${mangled} hit(s) still contain '${mod} : ${func}'"
+    fi
+done
+
+# 3. `kind` must reflect function / type / callback. Without this,
+#    callback `c:init/1` and function `init/1` look identical in
+#    results. The default attributesToRetrieve set on the index
+#    omits `kind`, so the test must request it explicitly.
+_check_kind() {
+    local app="$1" path="$2" expected="$3" query="$4"
+    resp=$(curl -fsS -X POST \
+        "https://${APP_ID}-dsn.algolia.net/1/indexes/${INDEX}/query" \
+        -H "X-Algolia-Application-Id: ${APP_ID}" \
+        -H "X-Algolia-API-Key: ${API_KEY}" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg q "$query" \
+                    --arg f "version:${VERSION} AND app:\"${app}\"" \
+                '{query: $q, filters: $f, hitsPerPage: 10, analytics: false,
+                  attributesToRetrieve: ["url", "kind"]}')")
+    got=$(echo "$resp" | jq -r --arg u "$path" \
+        '.hits[] | select(.url | contains($u)) | .kind' | head -1)
+    if [ "$got" = "$expected" ]; then
+        _report 1 "[crawler] kind ${path}" "${got}"
+    else
+        _report 0 "[crawler] kind ${path}" "got '${got}', want '${expected}'"
+    fi
+}
+_check_kind "stdlib" "/apps/stdlib/supervisor.html#c:init/1"      "callback" "supervisor:init"
+_check_kind "stdlib" "/apps/stdlib/gen_server.html#c:handle_cast/2" "callback" "gen_server:handle_cast"
+_check_kind "stdlib" "/apps/stdlib/gen_server.html#t:server_ref/0" "type"     "gen_server server_ref"
+_check_kind "stdlib" "/apps/stdlib/lists.html#append/2"           "function" "lists:append"
+
+# 4. Section records that have no narrative under the heading must
+#    be dropped from the index — they produce empty-excerpt hits.
+#    Module-overview records (lvl2 is null) are exempt: they're the
+#    landing page itself, kept regardless of content.
+#
+#    A specific URL doesn't make a good fixture here: anchors like
+#    `options-accepted-by-escript` get reused by parseDefinitionList
+#    as the fallback anchor for child <dt>/<dd> records, so the URL
+#    can still appear via the children even after the parent shell
+#    is dropped. Instead, assert globally that no non-overview hit
+#    in a broad sample has empty content.
+resp=$(curl -fsS -X POST \
+    "https://${APP_ID}-dsn.algolia.net/1/indexes/${INDEX}/query" \
+    -H "X-Algolia-Application-Id: ${APP_ID}" \
+    -H "X-Algolia-API-Key: ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg f "version:${VERSION}" \
+            '{query: "", filters: $f, hitsPerPage: 1000, analytics: false,
+              attributesToRetrieve: ["url", "content", "hierarchy.lvl2"]}')")
+empty_count=$(echo "$resp" | jq \
+    '[.hits[] | select((.content == "" or .content == null)
+                       and .hierarchy.lvl2 != null)] | length')
+if [ "$empty_count" = "0" ]; then
+    _report 1 "[crawler] no-empty-content (sample of 1000)" "0 empty-content non-overview hits"
+else
+    _report 0 "[crawler] no-empty-content (sample of 1000)" \
+        "${empty_count} hit(s) with empty content but non-null lvl2"
+fi
+
+# 4b. Chapter-page overview records (reference-manual chapters,
+#     other user-guide pages where h1 is immediately followed by
+#     h2) must have a useful excerpt — without the crawler's
+#     fallback they'd be title-only hits because the h1-to-h2
+#     gap is empty of narrative text.
+_check_overview_content() {
+    local path="$1" expected_prefix="$2" appname="$3" query="$4"
+    resp=$(curl -fsS -X POST \
+        "https://${APP_ID}-dsn.algolia.net/1/indexes/${INDEX}/query" \
+        -H "X-Algolia-Application-Id: ${APP_ID}" \
+        -H "X-Algolia-API-Key: ${API_KEY}" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg q "$query" \
+                    --arg f "version:${VERSION} AND app:\"$appname\"" \
+                '{query: $q, filters: $f, hitsPerPage: 20, analytics: false,
+                  attributesToRetrieve: ["url", "content"]}')")
+    got=$(echo "$resp" | jq -r --arg u "$path" \
+        '.hits[] | select(.url | endswith($u) or endswith($u + "#")) | .content' | head -1)
+    if [[ "$got" == "$expected_prefix"* ]]; then
+        _report 1 "[crawler] overview-content ${path}" "starts with '${expected_prefix}'"
+    else
+        _report 0 "[crawler] overview-content ${path}" \
+            "got '$(printf "%s" "$got" | head -c 60)', want prefix '${expected_prefix}'"
+    fi
+}
+_check_overview_content "/system/typespec.html" \
+    "Erlang is a dynamically typed language" \
+    "Erlang System Documentation" "typespec types"
+_check_overview_content "/system/modules.html" \
+    "Erlang code is divided into" \
+    "Erlang System Documentation" "modules"
+_check_overview_content "/system/ref_man_functions.html" \
+    "A function clause consists of" \
+    "Erlang System Documentation" "function declaration"
+
+# 5. Searching "reference manual" must surface multiple chapter
+#    overview records. The chapters (typespec, modules,
+#    ref_man_functions, ...) are user-guide pages whose
+#    module-overview record has empty content; without the
+#    anchor==='' carve-out in the filter, they'd vanish from the
+#    index. Today they're the top-15 hits for that query — assert
+#    we still see ≥10 of them.
+resp=$(_algolia_query "version:${VERSION}" "reference manual" 20)
+chapter_hits=$(echo "$resp" | jq -r \
+    '[.hits[] | select(.url | test("/system/[a-z_]+\\.html#?$"))] | length')
+if [ "$chapter_hits" -ge 10 ]; then
+    _report 1 "[crawler] reference-manual-chapters" "${chapter_hits} chapter pages"
+else
+    _report 0 "[crawler] reference-manual-chapters" \
+        "${chapter_hits} chapter pages (want ≥10)"
+fi
+# Verify a representative subset by URL.
+for chapter in reference_manual typespec modules ref_man_functions ref_man_records expressions; do
+    found=$(echo "$resp" | jq -r --arg u "/system/${chapter}.html" \
+        '[.hits[] | select(.url | endswith($u) or endswith($u + "#"))] | length')
+    if [ "$found" -gt 0 ]; then
+        _report 1 "[crawler] chapter-indexed ${chapter}" "present"
+    else
+        _report 0 "[crawler] chapter-indexed ${chapter}" "missing from 'reference manual' results"
+    fi
+done
+
+# 6. Sanity: section records with real content must stay indexed
+#    (they have non-empty content, so the filter shouldn't touch
+#    them — this guards against the filter being too aggressive).
+_check_present "/system/modules.html#module-syntax"                       "module syntax"        "Erlang System Documentation"
+_check_present "/system/ref_man_functions.html#function-declaration-syntax" "function declaration" "Erlang System Documentation"
+_check_present "/system/typespec.html#types-and-their-syntax"             "types syntax"         "Erlang System Documentation"
+
+# 7. Definition-list parsing. ExDoc renders markdown definition
+#    lists as `<ul><li><p><strong>term</strong> ...`, and
+#    parseDefinitionList walks that shape to emit one record per
+#    dt/dd pair with hierarchy.lvl3 = term text. If ExDoc ever
+#    changes the wrapper (e.g. drops the <strong>), this whole
+#    code path silently stops emitting records — there's no error,
+#    the items just vanish from the index.
+_check_present "/apps/erts/erl_cmd.html#+pad"           "+pad emulator flag"   "erts"
+_check_present "/apps/erts/erl_cmd.html#emulator-flags" "emulator flags"       "erts"
+
+# lvl3 must hold the dt term (with whatever modifier text follows
+# inside the <strong>). Catches the case where parseDefinitionList
+# emits records but loses the term text. _check_lvl3 picks the
+# top-ranked hit for the query whose URL contains the path — fine
+# when each dl-item has its own anchor (erl_cmd flags) and also
+# fine when dl-items share the parent's anchor (errors#exit-reasons,
+# erts_alloc#allocators) as long as the query disambiguates.
+_check_lvl3 "/apps/erts/erl_cmd.html#+pad"               "+pad"        "erts"   "+pad emulator flag"
+_check_lvl3 "/apps/erts/erl_cmd.html#file_name_encoding" "+fnl"        "erts"   "+fnl filename encoding"
+_check_lvl3 "/system/errors.html#exit-reasons"           "system_limit" "Erlang System Documentation" "system_limit exit reason"
+
+# A dl-item's content should lead with the dd body, not the dt
+# term — the dt is already in hierarchy.lvl3, so leaving it on
+# the front of content duplicates the term in the snippet. The
+# crawler strips the dt + separator before indexing.
+_check_content_prefix "/apps/erts/erl_cmd.html#+pad"     "The boolean value used with the +pad" "erts" "+pad emulator flag"
+_check_content_prefix "/system/errors.html#exit-reasons" "A system limit has been reached" "Erlang System Documentation" "system_limit exit reason"
+
+# A dl with many items must produce many child records — guards
+# against a regression where the parser bails out after the first
+# item or only picks up the last one.
+#
+# The index has `distinct: true, attributeForDistinct: "url"`, so
+# dl-items that share an anchor (because their <li> has no inner
+# [id]) collapse to one hit per query — `distinct: false` in the
+# request bypasses that so we can count them all.
+_count_dl_children() {
+    local label="$1" query="$2" appname="$3" lvl2="$4" url_contains="$5"
+    local want="$6"
+    resp=$(curl -fsS -X POST \
+        "https://${APP_ID}-dsn.algolia.net/1/indexes/${INDEX}/query" \
+        -H "X-Algolia-Application-Id: ${APP_ID}" \
+        -H "X-Algolia-API-Key: ${API_KEY}" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg q "$query" \
+                    --arg f "version:${VERSION} AND app:\"${appname}\"" \
+                '{query: $q, filters: $f, hitsPerPage: 200, distinct: false,
+                  analytics: false,
+                  attributesToRetrieve: ["url", "hierarchy.lvl2", "hierarchy.lvl3"]}')")
+    count=$(echo "$resp" | jq --arg l "$lvl2" --arg u "$url_contains" \
+        '[.hits[] | select(.hierarchy.lvl2 == $l
+                           and .hierarchy.lvl3 != null
+                           and (.url | contains($u)))] | length')
+    if [ "$count" -ge "$want" ]; then
+        _report 1 "[crawler] ${label}" "${count} children"
+    else
+        _report 0 "[crawler] ${label}" "${count} children (want ≥${want})"
+    fi
+}
+
+_count_dl_children "dl-children erl_cmd Emulator Flags" \
+    "emulator flags" "erts" "Emulator Flags" "erl_cmd" 15
+
+# erts_alloc has two distinct dl sections — "Allocators" (each
+# allocator name as a dt; <li> elements have no inner id so all
+# child records share #allocators as their URL anchor) and
+# "System Flags Effecting erts_alloc" (each flag-group heading as
+# a dt). Both shapes should produce many records.
+_check_lvl3          "/apps/erts/erts_alloc.html#allocators" "temp_alloc"  "erts" "temp_alloc allocator"
+_check_content_prefix "/apps/erts/erts_alloc.html#allocators" "Allocator used for temporary" "erts" "temp_alloc allocator"
+_check_lvl3 \
+    "/apps/erts/erts_alloc.html#flags-for-configuration-of-alloc_util" \
+    "Flags for Configuration of alloc_util" \
+    "erts" "flags for configuration of alloc_util"
+_count_dl_children "dl-children erts_alloc Allocators" \
+    "erts_alloc allocators" "erts" "Allocators" "erts_alloc" 5
+
+# erl_nif (the NIF C API) renders its "Data Types" section as a
+# definition list — each typedef name is a dt. These records have
+# lvl2 = "Data Types" and lvl3 = the type name. Different shape
+# from the function records (which are extracted via
+# section.detail), so worth its own coverage.
+_check_lvl3 \
+    "/apps/erts/erl_nif.html#ErlNifResourceType" "ErlNifResourceType" \
+    "erts" "ErlNifResourceType NIF resource"
+_check_content_prefix \
+    "/apps/erts/erl_nif.html#ErlNifResourceType" "Each instance of ErlNifResourceType represents" \
+    "erts" "ErlNifResourceType NIF resource"
+_count_dl_children "dl-children erl_nif Data Types" \
+    "erl_nif data types" "erts" "Data Types" "erl_nif" 5
+
+# erl_nif also has many C-function records (the bulk of the page,
+# extracted via the functions path, not parseDefinitionList). lvl2
+# should hold the full C signature. Catches a regression where the
+# signature collector picks up just the function name or empties.
+_check_lvl2 \
+    "/apps/erts/erl_nif.html#enif_alloc" "enif_alloc()" \
+    "erts" "enif_alloc NIF"
+_check_lvl2 \
+    "/apps/erts/erl_nif.html#enif_make_atom" "enif_make_atom()" \
+    "erts" "enif_make_atom"
+
+# 8. Sanity: function records always have hierarchy.lvl2 set to
+#    the full signature (mod-level lvl1, signature-level lvl2).
+#    Catches a regression where the function-extractor stops
+#    picking up signatures.
+_check_lvl2 "/apps/stdlib/lists.html#append/2"      "append(List1, List2)" "stdlib" "lists:append"
+_check_lvl2 "/apps/stdlib/gen_server.html#cast/2"   "cast(ServerRef"       "stdlib" "gen_server:cast"
+_check_lvl2 "/apps/ssl/ssl.html#connect/4"          "connect(Host, Port"   "ssl"    "ssl:connect"
+
 echo
 echo "Search regression check: ${PASS} passed, ${FAIL} failed (version ${VERSION})"
 [ "$FAIL" -eq 0 ]

--- a/_scripts/check_algolia_search.sh
+++ b/_scripts/check_algolia_search.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# Run a small set of well-known doc searches against Algolia and check
+# that each one returns the expected URL in its top 5 hits. Catches
+# the scraper-vs-ExDoc-HTML-shape drift that has bitten us before:
+# when ExDoc moves a CSS class or restructures a page, the scraper's
+# selectors silently produce different (or empty) records, and the
+# only visible symptom is that searches like "lists" stop finding
+# lists.html.
+#
+# Usage:  _scripts/check_algolia_search.sh [VERSION]
+# VERSION defaults to whatever is in ./LATEST_MAJOR_VSN.
+
+set -e
+set -o pipefail
+
+APP_ID="LUYTU1J2MB"
+API_KEY="86152ba1d4a9d7e179d537b8060a4c31"
+INDEX="erlang"
+
+VERSION="${1:-$(cat LATEST_MAJOR_VSN 2>/dev/null || echo 28)}"
+
+# Each test: filter | query | expected_url_substring | expected_lvl1
+# The lvl1 column is optional; leave it empty to skip the title check.
+# Filter syntax is Algolia's; "app" is the indexed application name.
+TESTS=(
+    'app:"stdlib"|lists|/apps/stdlib/lists.html|'
+    'app:"stdlib"|gen_server|/apps/stdlib/gen_server.html|'
+    'app:"stdlib"|binary|/apps/stdlib/binary.html|'
+    'app:"kernel"|file|/apps/kernel/file.html|'
+    'app:"erts"|erlang|/apps/erts/erlang.html|'
+    # Cross-app core-group case: "file" lives in kernel but we expect
+    # to find it when searching stdlib + kernel + erts together.
+    'app:"stdlib" OR app:"kernel" OR app:"erts"|file|/apps/kernel/file.html|'
+    'app:"ssl"|ssl|/apps/ssl/ssl.html|'
+    'app:"crypto"|crypto|/apps/crypto/crypto.html|'
+    'app:"public_key"|public_key|/apps/public_key/public_key.html|'
+    'app:"compiler"|compile|/apps/compiler/compile.html|'
+    'app:"common_test"|ct|/apps/common_test/ct.html|'
+    'app:"eunit"|eunit|/apps/eunit/eunit.html|'
+    'app:"Erlang System Documentation"|reference manual|/system/reference_manual.html|'
+    # Section-anchor and page-summary hits where the scraper should
+    # carry the page-level <h1> in lvl1. These currently fail because
+    # the scraper's selectors are tuned for ExDoc's module-page
+    # layout and miss the <h1> on user guides, system docs, and
+    # command-line tool pages. Same underlying bug across thousands
+    # of records — these three exemplify the common shapes.
+    'app:"Erlang System Documentation"|macro|/system/records_macros.html#macros|Records and Macros'
+    'app:"common_test"|write test suites|/apps/common_test/write_test_chapter.html|Writing Test Suites'
+    'app:"erts"|werl|/apps/erts/werl_cmd.html|werl'
+)
+
+PASS=0
+FAIL=0
+
+for test in "${TESTS[@]}"; do
+    IFS='|' read -r filter query expected_url expected_lvl1 <<< "$test"
+    full_filter="version:${VERSION} AND ${filter}"
+    label="[$filter] $query"
+
+    response=$(curl -fsS -X POST \
+        "https://${APP_ID}-dsn.algolia.net/1/indexes/${INDEX}/query" \
+        -H "X-Algolia-Application-Id: ${APP_ID}" \
+        -H "X-Algolia-API-Key: ${API_KEY}" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg q "$query" --arg f "$full_filter" \
+                '{query: $q, filters: $f, hitsPerPage: 5, analytics: false,
+                  attributesToRetrieve: ["url", "hierarchy.lvl1"]}')")
+
+    # Pick the first hit whose URL contains the expected substring.
+    match=$(echo "$response" | jq -r --arg u "$expected_url" \
+        '.hits[] | select(.url | contains($u)) | {url, lvl1: .hierarchy.lvl1} | @json' \
+        | head -1)
+
+    if [ -z "$match" ]; then
+        FAIL=$((FAIL + 1))
+        urls=$(echo "$response" | jq -r '.hits[].url' || echo "")
+        printf '  \033[31mFAIL\033[0m %-60s -> %s\n' "$label" "$expected_url"
+        printf '       got: %s\n' "${urls:-<no hits>}"
+        continue
+    fi
+
+    if [ -n "$expected_lvl1" ]; then
+        got_lvl1=$(echo "$match" | jq -r '.lvl1')
+        if [ "$got_lvl1" != "$expected_lvl1" ]; then
+            FAIL=$((FAIL + 1))
+            printf '  \033[31mFAIL\033[0m %-60s -> lvl1 "%s"\n' "$label" "$expected_lvl1"
+            printf '       got lvl1: "%s"\n' "$got_lvl1"
+            continue
+        fi
+    fi
+
+    PASS=$((PASS + 1))
+    printf '  \033[32mOK\033[0m   %-60s -> %s\n' "$label" "$expected_url"
+done
+
+echo
+echo "Search regression check: ${PASS} passed, ${FAIL} failed (version ${VERSION})"
+[ "$FAIL" -eq 0 ]

--- a/_scripts/download-docs.sh
+++ b/_scripts/download-docs.sh
@@ -116,6 +116,7 @@ make _redirects
 
 _scripts/otp_doc_sitemap.sh "${MAJOR_VSNs}" "${LATEST_MAJOR_VSN}" "${URL}${BASEURL}" > docs/sitemap_algolia.xml
 _scripts/otp_add_headers.sh docs
+node _scripts/add_dl_anchors.js docs
 
 ## Clean up leftover artifacts from downloads and flattening
 rm -rf docs/tmp docs/doc-* docs/*.tar.gz docs/*.zip

--- a/_scripts/otp_add_headers.sh
+++ b/_scripts/otp_add_headers.sh
@@ -38,6 +38,14 @@ _insert_before_title() {
 $tag" "$file" > "$file.tmp" && mv "$file.tmp" "$file"
 }
 
+# Insert `tag` before <title> only if `marker` isn't already in the file.
+_insert_before_title_once() {
+    local marker="$1"
+    local tag="$2"
+    local file="$3"
+    grep -q "$marker" "$file" || _insert_before_title "$tag" "$file"
+}
+
 DOCS_DIR="$1"
 shift
 LATEST_MAJOR_VSN="$(cat "LATEST_MAJOR_VSN")"
@@ -61,31 +69,35 @@ _fixup_search_link() {
     fi
 
     if [[ -n "$ex_doc_major" ]] && [[ "$ex_doc_major" -gt 0 || "$ex_doc_minor" -ge 39 ]]; then
-        DATA_ENGINE_URL_SEARCH='data-engine-url="search.html?q="'
-        EXDOC_SEARCH=$(grep "${DATA_ENGINE_URL_SEARCH}" "$1" || echo "")
-        if [ "$(echo "$EXDOC_SEARCH" | wc -w)" -gt "0" ]; then
+        if grep -q 'data-engine-url="search.html?q="' "$1"; then
             _sed_i 's@data-engine-url="search.html?q="@data-engine-url="/doc/search.html?v='"${MAJOR_VSN}"'\&q="@g' "$1"
         fi
     else
         META_FULL_TEXT_SEARCH="<meta name=\"exdoc:full-text-search-url\""
-        EXDOC_SEARCH=$(grep "${META_FULL_TEXT_SEARCH}" "$1" || echo "")
-        if [ ! "$(echo "$EXDOC_SEARCH" | wc -w)" -gt "0" ]; then
-            _insert_before_title "${META_FULL_TEXT_SEARCH} content=\"/doc/search.html?v=${MAJOR_VSN}\&q=\">" "$1"
-        fi
+        _insert_before_title_once "$META_FULL_TEXT_SEARCH" \
+            "${META_FULL_TEXT_SEARCH} content=\"/doc/search.html?v=${MAJOR_VSN}\&q=\">" "$1"
     fi
 }
 
 _fixup_major_version() {
-    MAJOR_VSN_SEARCH=$(grep "<meta name=\"major-vsn\" content=\"[0-9][0-9]*\"" "$1" || echo "")
-    if [ ! "$(echo "$MAJOR_VSN_SEARCH" | wc -w)" -gt "0" ]; then
-        _insert_before_title "<meta name=\"major-vsn\" content=\"${MAJOR_VSN}\">" "$1"
-    fi
+    _insert_before_title_once '<meta name="major-vsn" content="[0-9][0-9]*"' \
+        "<meta name=\"major-vsn\" content=\"${MAJOR_VSN}\">" "$1"
 }
 
 _disable_autocomplete() {
-    AUTOCOMPLETE_SEARCH=$(grep "<meta name=\"exdoc:autocomplete\" content=\"off\">" "$1" || echo "")
-    if [ ! "$(echo "$AUTOCOMPLETE_SEARCH" | wc -w)" -gt "0" ]; then
-        _insert_before_title '<meta name="exdoc:autocomplete" content="off">' "$1"
+    _insert_before_title_once '<meta name="exdoc:autocomplete" content="off">' \
+        '<meta name="exdoc:autocomplete" content="off">' "$1"
+}
+
+_inject_algolia_typeahead() {
+    # Skip if our marker is already there (the meta tag below is also
+    # an idempotency guard on its own). Disable ExDoc's Lunr
+    # autocomplete on the same pages so it doesn't render alongside
+    # the Algolia dropdown.
+    if ! grep -q "algolia-typeahead.js" "$1"; then
+        _disable_autocomplete "$1"
+        _insert_before_title '<link rel="stylesheet" href="/assets/css/algolia-typeahead.css">' "$1"
+        _insert_before_title '<script src="/assets/js/algolia-typeahead.js" defer></script>' "$1"
     fi
 }
 
@@ -117,6 +129,7 @@ _add_head_tags() {
         _fixup_major_version "${file}"
         if [ "$MAJOR_VSN" -gt "26" ]; then
             _fixup_search_link "${file}"
+            _inject_algolia_typeahead "${file}"
         fi
         _add_canonical "${file}"
     done
@@ -133,10 +146,6 @@ for MAJOR_VSN in ${MAJOR_VSNS}; do
     echo "Adding head tags for OTP ${MAJOR_VSN} in ${TARGET_DIR}"
     # shellcheck disable=SC2046
     _add_head_tags "${TARGET_DIR}"
-    if [ "${MAJOR_VSN}" -gt "26" ]; then
-        _disable_autocomplete "${TARGET_DIR}/"*.html
-        _disable_autocomplete "${TARGET_DIR}/system/"*.html
-    fi
 done
 
 exit 0

--- a/assets/css/algolia-typeahead.css
+++ b/assets/css/algolia-typeahead.css
@@ -1,0 +1,199 @@
+/* Algolia typeahead dropdown for ExDoc-generated pages. Loaded via
+   _scripts/otp_add_headers.sh into every OTP doc page. Class names
+   are prefixed `alg-` to avoid collision with ExDoc's own classes. */
+
+/* Hide ExDoc's Lunr autocomplete UI on pages where we provide an
+   Algolia typeahead. The exdoc:autocomplete=off meta covers newer
+   ExDoc bundles; this CSS rule is the fallback for older ones that
+   still render the container regardless. */
+.autocomplete-container,
+.autocomplete-suggestions,
+.autocomplete {
+  display: none !important;
+}
+
+.alg-dropdown {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  top: 55px;
+  z-index: 200;
+  background: var(--autocompleteBackground, #fff);
+  border: 1px solid var(--autocompleteBorder, rgba(3, 9, 19, 0.1));
+  border-radius: var(--borderRadius-base, 8px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  max-height: 480px;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  font-size: 0.9rem;
+  color: var(--textBody, #1a202c);
+}
+
+.alg-dropdown[hidden] {
+  display: none;
+}
+
+/* Scope pills row at the top of the dropdown. Only rendered on
+   pages where the app context exists; hidden on umbrella pages. */
+.alg-scope {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--suggestionBorder, rgba(0, 0, 0, 0.06));
+  font-size: 0.75em;
+  opacity: 0.85;
+}
+
+.alg-scope-pill {
+  appearance: none;
+  border: 1px solid var(--suggestionBorder, rgba(0, 0, 0, 0.12));
+  background: transparent;
+  color: inherit;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: inherit;
+  font-family: inherit;
+  cursor: pointer;
+  line-height: 1.4;
+}
+
+.alg-scope-pill:hover {
+  background: var(--autocompleteHover, rgba(0, 0, 0, 0.04));
+}
+
+.alg-scope-pill.alg-active {
+  background: var(--mainLight, #a2003e);
+  color: #fff;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.alg-empty a {
+  color: var(--mainLight, #a2003e);
+}
+
+.alg-results {
+  padding: 4px 0;
+}
+
+.alg-hit {
+  display: block;
+  padding: 10px 16px;
+  text-decoration: none;
+  color: var(--textHeaders, #1a202c);
+  border-top: 1px solid var(--suggestionBorder, rgba(0, 0, 0, 0.06));
+  transition: background-color 0.1s ease;
+}
+
+.alg-hit:first-child {
+  border-top: 0;
+}
+
+.alg-hit:hover,
+.alg-hit.alg-selected {
+  background: var(--autocompleteHover, rgba(0, 0, 0, 0.04));
+  text-decoration: none;
+}
+
+.alg-hit-title {
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.alg-hit-excerpt {
+  margin-top: 4px;
+  font-size: 0.82em;
+  opacity: 0.8;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+/* Algolia's highlight markers come back as
+   <span class="algolia-docsearch-suggestion--highlight">. */
+.alg-hit .algolia-docsearch-suggestion--highlight {
+  background: var(--autocompleteLabelBack, #fff1c2);
+  font-weight: 700;
+  padding: 0 1px;
+  border-radius: 2px;
+}
+
+.alg-empty {
+  padding: 14px 16px;
+  opacity: 0.7;
+  font-size: 0.9em;
+}
+
+.alg-empty.alg-loading::after {
+  content: '';
+  display: inline-block;
+  width: 0.7em;
+  height: 0.7em;
+  margin-left: 8px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  vertical-align: -1px;
+  animation: alg-spin 0.8s linear infinite;
+}
+
+@keyframes alg-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Footer row — required "Search by Algolia" attribution plus an
+   optional keyboard-hint span. */
+.alg-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 12px;
+  border-top: 1px solid var(--suggestionBorder, rgba(0, 0, 0, 0.06));
+  font-size: 0.72em;
+  letter-spacing: 0.02em;
+  color: var(--textBody, #4a5568);
+  background: var(--autocompleteSelected, rgba(0, 0, 0, 0.02));
+}
+
+.alg-footer-hint {
+  opacity: 0.7;
+}
+
+.alg-footer-hint kbd {
+  font-family: inherit;
+  font-size: 0.92em;
+  padding: 1px 5px;
+  margin: 0 1px;
+  background: var(--autocompleteLabelBack, rgba(0, 0, 0, 0.06));
+  border: 1px solid var(--suggestionBorder, rgba(0, 0, 0, 0.12));
+  border-radius: 3px;
+}
+
+.alg-footer-attribution {
+  margin-left: auto;
+  text-decoration: none;
+  color: inherit;
+  opacity: 0.7;
+}
+
+.alg-footer-attribution:hover {
+  opacity: 1;
+  text-decoration: none;
+}
+
+.alg-footer-attribution strong {
+  font-weight: 700;
+  color: #003dff;
+}
+
+/* Dark theme — ExDoc toggles via body.dark or [data-theme=dark] */
+body.dark .alg-footer-attribution strong,
+[data-theme="dark"] .alg-footer-attribution strong {
+  color: #5468ff;
+}

--- a/assets/js/algolia-typeahead.js
+++ b/assets/js/algolia-typeahead.js
@@ -1,0 +1,526 @@
+/*
+ * Algolia-backed typeahead for OTP docs.
+ *
+ * Replaces ExDoc's Lunr autocomplete with an Algolia DocSearch query,
+ * scoped to the version being viewed plus (on per-app pages) the
+ * current application. Designed to be injected by
+ * _scripts/otp_add_headers.sh into every ExDoc-generated page.
+ *
+ * No bundler, no SDK — keeps the script small and version-agnostic so
+ * it works against every OTP/ExDoc version we ship docs for. Will be
+ * deleted once https://github.com/elixir-lang/ex_doc gains a JS
+ * registerSearchProvider hook and we can use that instead.
+ */
+(function () {
+  'use strict';
+
+  // Public DocSearch credentials — search-only, safe in client code.
+  // Mirrors the values in assets/doc-search.tsx and _layouts/search.html;
+  // rotate all three together if these ever change.
+  var APP_ID = 'LUYTU1J2MB';
+  var API_KEY = '86152ba1d4a9d7e179d537b8060a4c31';
+  var INDEX = 'erlang';
+  var DEBOUNCE_MS = 120;
+  var MAX_HITS = 8;
+
+  // Logical groups of OTP applications that get searched together
+  // when scope is "app". When the current page is in any group
+  // member, the search spans every app in that group. Apps not in
+  // any group are scoped to themselves alone.
+  var APP_GROUPS = [
+    { name: 'core',     apps: ['stdlib', 'kernel', 'erts'] },
+    { name: 'security', apps: ['ssl', 'crypto', 'public_key', 'ssh'] },
+    { name: 'code',     apps: ['compiler', 'syntax_tools', 'parsetools'] },
+    { name: 'test',     apps: ['common_test', 'eunit'] },
+    { name: 'system',   apps: ['Erlang System Documentation'] },
+  ];
+  function groupByName(name) {
+    for (var i = 0; i < APP_GROUPS.length; i++) {
+      if (APP_GROUPS[i].name === name) return APP_GROUPS[i];
+    }
+    return null;
+  }
+  function groupFor(app) {
+    if (!app) return null;
+    for (var i = 0; i < APP_GROUPS.length; i++) {
+      if (APP_GROUPS[i].apps.indexOf(app) >= 0) return APP_GROUPS[i];
+    }
+    return null;
+  }
+  function defaultScope(ctx) {
+    // Default scope is the group containing the current app when
+    // there is one (typical case for apps that have siblings —
+    // stdlib defaults to "core"), otherwise the current app alone,
+    // otherwise just the version.
+    if (!ctx.application) return 'all';
+    var g = groupFor(ctx.application);
+    return g ? g.name : ctx.application;
+  }
+
+  // Tab cycles scope through these ids in order. Suppress the
+  // current-app entry when it duplicates a single-member group.
+  // On unscoped pages (umbrella index, redirect stubs) there's no
+  // natural "current" app, so cycle through every group instead.
+  function tabCycle(ctx) {
+    if (!ctx.application) {
+      var all = APP_GROUPS.map(function (g) { return g.name; });
+      all.push('all');
+      return all;
+    }
+    var g = groupFor(ctx.application);
+    var cycle = [];
+    if (!g || g.apps.length > 1) cycle.push(ctx.application);
+    if (g) cycle.push(g.name);
+    cycle.push('all');
+    return cycle;
+  }
+
+  function meta(name) {
+    var el = document.querySelector('meta[name="' + name + '"]');
+    return el ? el.getAttribute('content') : null;
+  }
+
+  // Strip the trailing " v1.2.3" / " v1.2.3-rc0" from a project meta
+  // value, leaving just the application name as Algolia indexes it.
+  function appFromProject(project) {
+    if (!project) return null;
+    return project.replace(/\s+v[\d.]+(-[A-Za-z0-9.]+)?\s*$/, '');
+  }
+
+  function getContext() {
+    var majorVsn = meta('major-vsn');
+    var project = meta('project');
+    if (!majorVsn) return null;
+    // Per-app pages: /doc(s/<v>)?/apps/<app>/...
+    // System docs pages: /doc(s/<v>)?/system/... (indexed as the
+    //   "Erlang System Documentation" app)
+    // Anything else (redirect stubs at /doc/foo.html) gets no app
+    // scope — pill is hidden and search is global within the version.
+    var path = window.location.pathname;
+    var isScopedPage = /\/(apps\/[^/]+|system)\//.test(path);
+    return {
+      version: majorVsn,
+      application: isScopedPage ? appFromProject(project) : null,
+    };
+  }
+
+  // scope state is one of:
+  //   'all'           — no app filter, just the version
+  //   '<group name>'  — every app in the named APP_GROUPS entry
+  //   '<app name>'    — a single application (current page's app)
+  //
+  // Persistence stores the *level* — 'app', 'group', or 'all' — not
+  // the concrete scope. So a user who searched at the "group" level
+  // while in stdlib (group: core) and then navigates to a compiler
+  // page gets the "code" group, not still "core". Adapts the
+  // resolved scope to the page while preserving the user's intent.
+  //
+  // On unscoped pages (umbrella index, redirect stubs) there's no
+  // page-derived group, so we also remember the last group name the
+  // user picked and use it as the tiebreaker when level=group.
+  var SCOPE_KEY = 'erlang-org:algolia-scope-level';
+  var GROUP_KEY = 'erlang-org:algolia-last-group';
+  function scopeToLevel(scope) {
+    if (scope === 'all') return 'all';
+    if (groupByName(scope)) return 'group';
+    return 'app';
+  }
+  function lastGroup() {
+    try {
+      var v = sessionStorage.getItem(GROUP_KEY);
+      return v && groupByName(v) ? v : null;
+    } catch (_) { return null; }
+  }
+  function levelToScope(level, ctx) {
+    if (level === 'all') return 'all';
+    if (level === 'group') {
+      var g = groupFor(ctx.application);
+      if (g) return g.name;
+      return lastGroup() || APP_GROUPS[0].name;
+    }
+    // 'app'
+    return ctx.application || 'all';
+  }
+  function loadScope(ctx) {
+    try {
+      var level = sessionStorage.getItem(SCOPE_KEY);
+      if (level === 'app' || level === 'group' || level === 'all') {
+        return levelToScope(level, ctx);
+      }
+    } catch (_) { /* fall through */ }
+    return defaultScope(ctx);
+  }
+  function saveScope(scope) {
+    try {
+      sessionStorage.setItem(SCOPE_KEY, scopeToLevel(scope));
+      if (groupByName(scope)) sessionStorage.setItem(GROUP_KEY, scope);
+    } catch (_) { /* no-op */ }
+  }
+
+  function buildFilters(ctx, scope) {
+    var parts = ['version:' + ctx.version];
+    if (scope === 'all') return parts.join(' AND ');
+    var g = groupByName(scope);
+    if (g) {
+      var or = g.apps.map(function (a) {
+        return 'app:' + JSON.stringify(a);
+      }).join(' OR ');
+      parts.push('(' + or + ')');
+    } else {
+      // Single app
+      parts.push('app:' + JSON.stringify(scope));
+    }
+    return parts.join(' AND ');
+  }
+
+  function search(query, ctx, scope, signal) {
+    var analytics = window.__algoliaAnalytics !== false;
+    return fetch(
+      'https://' + APP_ID + '-dsn.algolia.net/1/indexes/' + INDEX + '/query',
+      {
+        method: 'POST',
+        headers: {
+          'X-Algolia-Application-Id': APP_ID,
+          'X-Algolia-API-Key': API_KEY,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: query,
+          filters: buildFilters(ctx, scope),
+          hitsPerPage: MAX_HITS,
+          analytics: analytics,
+          attributesToRetrieve: [
+            'hierarchy.lvl1', 'hierarchy.lvl2', 'hierarchy.lvl3',
+            'url', 'isModule',
+          ],
+          attributesToHighlight: [
+            'hierarchy.lvl1', 'hierarchy.lvl2', 'hierarchy.lvl3',
+          ],
+          attributesToSnippet: ['content:30'],
+        }),
+        signal: signal,
+      }
+    ).then(function (res) {
+      if (!res.ok) throw new Error('algolia ' + res.status);
+      return res.json();
+    }).then(function (j) {
+      return j.hits || [];
+    });
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+
+  // Algolia returns highlight/snippet values with safe markup around
+  // matches (a <span class="algolia-docsearch-suggestion--highlight">),
+  // but un-tagged values need HTML escaping.
+  function hierarchyHL(hit, lvl) {
+    var hl = hit._highlightResult;
+    var h = hl && hl.hierarchy && hl.hierarchy[lvl];
+    if (h && h.value) return h.value;
+    var raw = hit.hierarchy && hit.hierarchy[lvl];
+    return raw ? escapeHtml(raw) : '';
+  }
+
+  function contentSnippet(hit) {
+    var sr = hit._snippetResult;
+    return sr && sr.content && sr.content.value ? sr.content.value : '';
+  }
+
+  // Title mirrors /doc/search.html's hit-name template: module hits
+  // read as `lvl1[:lvl2]` (e.g. "lists:foreach(Fun, List)"), non-module
+  // hits as `lvl1[ → lvl2][ → lvl3]` (breadcrumb for guides/system
+  // docs/command pages).
+  function hitTitle(hit) {
+    var lvl1 = hierarchyHL(hit, 'lvl1');
+    var lvl2 = hierarchyHL(hit, 'lvl2');
+    var lvl3 = hierarchyHL(hit, 'lvl3');
+    if (hit.isModule) {
+      return lvl2 ? (lvl1 + ':' + lvl2) : (lvl1 || '(untitled)');
+    }
+    var parts = [lvl1 || '(untitled)'];
+    if (lvl2) parts.push(lvl2);
+    if (lvl3) parts.push(lvl3);
+    return parts.join(' &rsaquo; ');
+  }
+
+  function renderHits(target, hits, query, scope) {
+    if (!hits.length) {
+      var hint = '';
+      if (scope !== 'all') {
+        hint = ' Try widening the scope (Tab).';
+      }
+      target.innerHTML =
+        '<div class="alg-empty">No results for ' +
+        '<strong>' + escapeHtml(query) + '</strong>.' + hint + '</div>';
+      return;
+    }
+    var html = '';
+    for (var i = 0; i < hits.length; i++) {
+      var h = hits[i];
+      var title = hitTitle(h);
+      var excerpt = contentSnippet(h);
+      html +=
+        '<a class="alg-hit" href="' + escapeHtml(h.url) +
+        '" data-index="' + i + '" role="option">' +
+        '<div class="alg-hit-title">' + title + '</div>' +
+        (excerpt ? '<div class="alg-hit-excerpt">' + excerpt + '</div>' : '') +
+        '</a>';
+    }
+    target.innerHTML = html;
+  }
+
+  function debounce(fn, ms) {
+    var t;
+    return function () {
+      var self = this, args = arguments;
+      clearTimeout(t);
+      t = setTimeout(function () { fn.apply(self, args); }, ms);
+    };
+  }
+
+  function mount(input, ctx) {
+    // Clone the input to detach ExDoc's Lunr listeners. The `/`
+    // keyboard shortcut is bound on document and finds the input by
+    // class, so it still focuses the replacement.
+    var fresh = input.cloneNode(true);
+    input.parentNode.replaceChild(fresh, input);
+    input = fresh;
+
+    var wrap = document.createElement('div');
+    wrap.className = 'alg-dropdown';
+    wrap.setAttribute('role', 'listbox');
+    wrap.hidden = true;
+
+    // Scope pill row — one pill per APP_GROUPS entry, plus the
+    // current page's app when it's not in any group, plus an
+    // "all OTP" pill that disables the app filter.
+    var scope = loadScope(ctx);
+    var pillButtons = []; // [{ id, el }]
+
+    var pillRow = document.createElement('div');
+    pillRow.className = 'alg-scope';
+    pillRow.appendChild(document.createTextNode('Searching: '));
+
+    function makePill(id, label, title) {
+      var b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'alg-scope-pill';
+      b.setAttribute('data-scope', id);
+      b.textContent = label;
+      if (title) b.title = title;
+      b.addEventListener('click', function () { setScope(id); input.focus(); });
+      pillButtons.push({ id: id, el: b });
+      return b;
+    }
+
+    // Current app pill goes first (default scope), unless it would
+    // duplicate a single-member group (e.g. system).
+    if (ctx.application) {
+      var ownGroup = groupFor(ctx.application);
+      if (!ownGroup || ownGroup.apps.length > 1) {
+        pillRow.appendChild(makePill(ctx.application, ctx.application, ctx.application));
+      }
+    }
+    for (var gi = 0; gi < APP_GROUPS.length; gi++) {
+      var g = APP_GROUPS[gi];
+      pillRow.appendChild(makePill(g.name, g.name, g.apps.join(', ')));
+    }
+    pillRow.appendChild(makePill('all', 'all OTP', 'every OTP application in this version'));
+
+    wrap.appendChild(pillRow);
+
+    var results = document.createElement('div');
+    results.className = 'alg-results';
+
+    var footer = document.createElement('div');
+    footer.className = 'alg-footer';
+    if (tabCycle(ctx).length > 1) {
+      var hint = document.createElement('span');
+      hint.className = 'alg-footer-hint';
+      hint.innerHTML = '<kbd>Tab</kbd> to switch scope';
+      footer.appendChild(hint);
+    }
+    var attribution = document.createElement('a');
+    attribution.className = 'alg-footer-attribution';
+    attribution.href = 'https://www.algolia.com/';
+    attribution.target = '_blank';
+    attribution.rel = 'noopener';
+    attribution.innerHTML = 'Search by <strong>Algolia</strong>';
+    footer.appendChild(attribution);
+
+    wrap.appendChild(results);
+    wrap.appendChild(footer);
+
+    var host = input.closest('.search-bar') || input.parentNode;
+    host.style.position = host.style.position || 'relative';
+    host.appendChild(wrap);
+
+    var ctrl = null;
+    var hits = [];
+    var selected = -1;
+
+    function updateScopePills() {
+      for (var i = 0; i < pillButtons.length; i++) {
+        pillButtons[i].el.classList.toggle('alg-active', pillButtons[i].id === scope);
+      }
+    }
+    updateScopePills();
+
+    function setScope(next) {
+      if (next === scope) return;
+      scope = next;
+      saveScope(scope);
+      updateScopePills();
+      if (input.value.trim()) runQuery();
+    }
+
+    function tabToNextScope() {
+      var cycle = tabCycle(ctx);
+      if (cycle.length <= 1) return;
+      var i = cycle.indexOf(scope);
+      var next = i < 0 ? cycle[0] : cycle[(i + 1) % cycle.length];
+      setScope(next);
+    }
+
+
+    function updateSelected() {
+      var els = results.querySelectorAll('.alg-hit');
+      for (var i = 0; i < els.length; i++) {
+        if (i === selected) {
+          els[i].classList.add('alg-selected');
+          els[i].setAttribute('aria-selected', 'true');
+          els[i].scrollIntoView({ block: 'nearest' });
+        } else {
+          els[i].classList.remove('alg-selected');
+          els[i].removeAttribute('aria-selected');
+        }
+      }
+    }
+
+    var loadingTimer = null;
+    function runQuery() {
+      var q = input.value.trim();
+      if (ctrl) ctrl.abort();
+      if (loadingTimer) clearTimeout(loadingTimer);
+      if (!q) {
+        wrap.hidden = true;
+        results.innerHTML = '';
+        hits = [];
+        selected = -1;
+        return;
+      }
+      // Show a "Searching…" placeholder if the request takes longer
+      // than ~200 ms, so slow networks have visible feedback without
+      // flickering on fast ones.
+      loadingTimer = setTimeout(function () {
+        results.innerHTML = '<div class="alg-empty alg-loading">Searching…</div>';
+        wrap.hidden = false;
+      }, 200);
+      ctrl = new AbortController();
+      search(q, ctx, scope, ctrl.signal).then(function (rs) {
+        clearTimeout(loadingTimer);
+        hits = rs;
+        selected = -1;
+        renderHits(results, hits, q, scope);
+        wrap.hidden = false;
+      }).catch(function (err) {
+        clearTimeout(loadingTimer);
+        if (err.name === 'AbortError') return;
+        // Network / Algolia error — fall back to a link to the full
+        // search page so the user still has a way to query.
+        var fallback = '/doc/search.html?v=' + encodeURIComponent(ctx.version) +
+                       '&q=' + encodeURIComponent(q);
+        results.innerHTML =
+          '<div class="alg-empty">Search unavailable. ' +
+          '<a href="' + fallback + '">Open full search</a>.</div>';
+        wrap.hidden = false;
+        // Log in case it's not just transient.
+        if (window.console && console.warn) console.warn('algolia-typeahead:', err);
+      });
+    }
+
+    var onInput = debounce(runQuery, DEBOUNCE_MS);
+    input.addEventListener('input', onInput);
+
+    input.addEventListener('focus', function () {
+      if (hits.length) wrap.hidden = false;
+    });
+
+    // Capture-phase handler for Enter and Tab so they run *before*
+    // ExDoc's listeners (Enter triggers their form submit; Tab
+    // would move focus out of the input). stopImmediatePropagation
+    // keeps ExDoc from acting on them.
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' && !wrap.hidden && selected >= 0 && hits[selected]) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        window.location.href = hits[selected].url;
+        return;
+      }
+      if (e.key === 'Tab' && !e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey
+          && tabCycle(ctx).length > 1) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        tabToNextScope();
+        return;
+      }
+    }, true);
+
+    // Bubble-phase handler for navigation keys. Mirrors the bindings
+    // ExDoc's own search-bar.js uses so users with muscle memory get
+    // the same behaviour:
+    //   Up / Ctrl+P    -> select previous hit
+    //   Down / Ctrl+N  -> select next hit
+    //   Escape         -> close dropdown and blur the input
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        if (!wrap.hidden) {
+          wrap.hidden = true;
+          selected = -1;
+        }
+        input.blur();
+        return;
+      }
+
+      if (wrap.hidden) return;
+      var nextHit = e.key === 'ArrowDown' || (e.ctrlKey && e.key === 'n');
+      var prevHit = e.key === 'ArrowUp'   || (e.ctrlKey && e.key === 'p');
+      if (nextHit) {
+        e.preventDefault();
+        selected = Math.min(selected + 1, hits.length - 1);
+        updateSelected();
+      } else if (prevHit) {
+        e.preventDefault();
+        selected = Math.max(selected - 1, -1);
+        updateSelected();
+      }
+    });
+
+    document.addEventListener('click', function (e) {
+      if (e.target === input) return;
+      if (wrap.contains(e.target)) return;
+      wrap.hidden = true;
+    });
+  }
+
+  function init() {
+    var ctx = getContext();
+    if (!ctx) {
+      // Missing meta tags — page probably isn't an ExDoc page we care about.
+      return;
+    }
+    var input = document.querySelector('.search-input');
+    if (!input) return;
+    mount(input, ctx);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
This PR adds a new primary search interface to erlang.org/doc/ replacing the built-in ExDoc one.

I also vendored the algolia crawler config and added some tests for the search results to make sure they don't deteriorate as we adapt new exdoc versions.